### PR TITLE
Check the branch naming and put label automatically for the PR

### DIFF
--- a/.github/auto-label.yml
+++ b/.github/auto-label.yml
@@ -1,0 +1,39 @@
+name: Auto Label Jira Ticket
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Get branch name
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+
+      - name: Map prefix to label
+        id: map
+        run: |
+          case "${BRANCH_NAME}" in
+            */IDN-*) echo "LABEL=Infra" >> $GITHUB_ENV ;;
+            */DKN-*) echo "LABEL=Dukan" >> $GITHUB_ENV ;;
+            */CHT-*) echo "LABEL=Chat" >> $GITHUB_ENV ;;
+            */FTH-*) echo "LABEL=Faith" >> $GITHUB_ENV ;;
+            */TRN-*) echo "LABEL=Trends" >> $GITHUB_ENV ;;
+            */WLT-*) echo "LABEL=Wallet" >> $GITHUB_ENV ;;
+            *) echo "LABEL=" >> $GITHUB_ENV ;;
+          esac
+
+      - name: Add label to PR
+        if: env.LABEL != ''
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ env.LABEL }}

--- a/.github/branch-name-check.yml
+++ b/.github/branch-name-check.yml
@@ -1,0 +1,68 @@
+name: Enforce Branch Naming Convention
+
+on:
+  pull_request:
+    types: [ opened, reopened, edited, synchronize ]
+
+jobs:
+  enforce-branch-name:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Validate branch name
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = context.payload.pull_request.head.ref;
+            const prNumber = context.payload.pull_request.number;
+            
+            console.log(`Validating branch name: ${branchName} for PR #${prNumber}`);
+
+            const regex = /^(feature|fix|refactor|test)\/(IDN|DKN|CHT|FTH|TRN|WLT)-[0-9]+(-[a-z0-9-]+)*$/;
+
+            if (!regex.test(branchName)) {
+              const commentBody = `
+              ❌ **Invalid Branch Name: \`${branchName}\`**
+
+              Thank you for your contribution! However, the branch name does not follow our required naming convention. 
+              This check must pass before the pull request can be merged.
+
+              **Please rename your branch to match the following pattern:**
+              \`<type>/<jira-key>-<short-description>\`
+
+              ---
+              #### Pattern Breakdown:
+              - **type**: One of \`feature\`, \`fix\`, \`refactor\`, \`test\`.
+              - **jira-key**: One of \`IDN\`, \`DKN\`, \`CHT\`, \`FTH\`, \`TRN\`, \`WLT\`, followed by a hyphen and the issue number.
+              - **short-description**: A short description of the change (e.g., \`add-user-login\`).
+
+              ---
+              #### Examples of valid branch names:
+              - \`feature/IDN-123-add-user-login\`
+              - \`fix/TRN-45-update-payment-gateway\`
+
+              ---
+              #### How to fix this:
+              1. Go back to your local repository and rename the branch:
+                 \`\`\`
+                 git branch -m ${branchName} <new-branch-name>
+                 \`\`\`
+              2. Push the renamed branch to the remote repository. You may need to use force push:
+                 \`\`\`
+                 git push origin -u <new-bottom-name> --force
+                 \`\`\`
+              3. Please make a new PR with the updated branch.
+              `;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              core.setFailed('Branch name does not follow the required naming convention.');
+            } else {
+              console.log('✅ Branch name is valid.');
+            }


### PR DESCRIPTION
# Changes: 
- Add ci to check the branch naming for an opened PR.
- Add ci to put the PR label automatically.