### PR TITLE
Hotfix: Remove leftover merge marker from dev

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanShelfService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanShelfService.kt
@@ -1,15 +1,11 @@
 package net.thechance.dukan.service
 
-re/DKN-50-Create-endpoint-that-returns-the-product-from-a-certain-shelf
-import net.thechance.dukan.entity.DukanProduct
 import net.thechance.dukan.entity.DukanShelf
 import net.thechance.dukan.exception.ShelfDeletionNotAllowedException
 import net.thechance.dukan.exception.ShelfNameAlreadyTakenException
 import net.thechance.dukan.exception.ShelfNotFoundException
 import net.thechance.dukan.repository.DukanProductRepository
 import net.thechance.dukan.repository.DukanShelfRepository
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.util.UUID
 


### PR DESCRIPTION
## what is the PR Scope ?
This PR removes a leftover merge marker line that was mistakenly committed during conflict resolution of DKN-50.


## why do we need that ?
The stray line breaks the build and causes dev to crash. Removing it unblocks the development branch .

## end points with the request and response body:
N/A — this PR is a hotfix for code cleanup only, no new endpoints or API changes are introduced.
