### PR TITLE
use dukan schema for insert dukan colors

### DIFF
--- a/dukan/src/main/resources/db-dukan/changelog/changelogs/changelog-009-insert-colors.yaml
+++ b/dukan/src/main/resources/db-dukan/changelog/changelogs/changelog-009-insert-colors.yaml
@@ -5,6 +5,7 @@ databaseChangeLog:
       changes:
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -14,6 +15,7 @@ databaseChangeLog:
                   value: "#000000"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -23,6 +25,7 @@ databaseChangeLog:
                   value: "#B37DFF"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -32,6 +35,7 @@ databaseChangeLog:
                   value: "#C30C30"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -41,6 +45,7 @@ databaseChangeLog:
                   value: "#F77053"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -50,6 +55,7 @@ databaseChangeLog:
                   value: "#F4C343"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id
@@ -59,6 +65,7 @@ databaseChangeLog:
                   value: "#739E61"
         - insert:
             tableName: dukan_colors
+            schemaName: dukan
             columns:
               - column:
                   name: id


### PR DESCRIPTION
## what is the PR Scope ?
fix deployment backend by specify the schema to insert colors 

## why do we need that ?

we need this so the deployment success for inserting colors 
## end points with the request and response body:
