### PR TITLE
Feature/TRN-49-add deleting the video from storage

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/exception/TrendExceptions.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/exception/TrendExceptions.kt
@@ -14,3 +14,5 @@ class InvalidTrendInputException: TrendExceptions("Invalid input")
 class InvalidVideoException: TrendExceptions("Invalid video")
 
 class VideoUploadFailedException: TrendExceptions("Video upload failed")
+
+class VideoDeleteFailedException: TrendExceptions("Failed to delete video from storage")

--- a/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
@@ -43,8 +43,7 @@ class ReelsService(
             ?: throw ReelNotFoundException()
 
         runCatching {
-            reelsRepository.deleteById(id)
-            videoStorageService.deleteVideo(reel.videoUrl)
+            if (videoStorageService.deleteVideo(reel.videoUrl)) reelsRepository.deleteById(id)
         }.onFailure {
             throw VideoDeleteFailedException()
         }

--- a/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
@@ -1,5 +1,6 @@
 package net.thechance.trends.service
 
+import net.thechance.trends.exception.InvalidTrendInputException
 import net.thechance.trends.exception.InvalidVideoException
 import net.thechance.trends.exception.VideoUploadFailedException
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.time.LocalDateTime
@@ -49,6 +51,23 @@ class VideoStorageService(
             .contentType(contentType)
             .acl(ObjectCannedACL.PUBLIC_READ)
             .build()
+    }
+
+    fun deleteVideo(videoUrl: String) {
+
+        val prefix = "${trendsStorageProperties.cdnEndpoint}/${trendsStorageProperties.bucket}/"
+        if (!videoUrl.startsWith(prefix)) {
+            throw InvalidTrendInputException()
+        }
+
+        val key = videoUrl.removePrefix(prefix)
+
+        val deleteRequest = DeleteObjectRequest.builder()
+            .bucket(trendsStorageProperties.bucket)
+            .key(key)
+            .build()
+
+        trendsS3Client.deleteObject(deleteRequest)
     }
 
     private companion object {

--- a/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
@@ -38,7 +38,7 @@ class VideoStorageService(
             val key = "video/$folderName/$fileName"
             val putReq = createObjectRequest(key, mimeType)
             trendsS3Client.putObject(putReq, RequestBody.fromBytes(file.bytes))
-            return "${trendsStorageProperties.cdnEndpoint}/${trendsStorageProperties.bucket}/$key"
+            return "${trendsStorageProperties.cdnEndpoint}/$key"
         }.getOrElse {
             throw VideoUploadFailedException()
         }
@@ -54,7 +54,7 @@ class VideoStorageService(
     }
 
     fun deleteVideo(videoUrl: String): Boolean {
-        val prefix = "${trendsStorageProperties.cdnEndpoint}/${trendsStorageProperties.bucket}/"
+        val prefix = trendsStorageProperties.cdnEndpoint
         if (!videoUrl.startsWith(prefix)) {
             throw InvalidTrendInputException()
         }

--- a/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/VideoStorageService.kt
@@ -53,8 +53,7 @@ class VideoStorageService(
             .build()
     }
 
-    fun deleteVideo(videoUrl: String) {
-
+    fun deleteVideo(videoUrl: String): Boolean {
         val prefix = "${trendsStorageProperties.cdnEndpoint}/${trendsStorageProperties.bucket}/"
         if (!videoUrl.startsWith(prefix)) {
             throw InvalidTrendInputException()
@@ -67,7 +66,9 @@ class VideoStorageService(
             .key(key)
             .build()
 
-        trendsS3Client.deleteObject(deleteRequest)
+        val response = trendsS3Client.deleteObject(deleteRequest)
+
+        return response.sdkHttpResponse().isSuccessful
     }
 
     private companion object {


### PR DESCRIPTION
## what is the PR Scope ?
- Added the logic of deleting video from bucket

## why do we need that ?
- We need when delete the video to delete it from both database and from storage too

## end points with the request and response body:
`trends/reels/{id}`
and there is no response body



https://github.com/user-attachments/assets/465300dc-eed3-4fc3-bbec-991ee9e8900f

