### PR TITLE
modify image url coulmn in dukan table to accept nullable values

### DIFF
--- a/dukan/src/main/resources/db-dukan/changelog/changelogs/changelogs_011.yaml
+++ b/dukan/src/main/resources/db-dukan/changelog/changelogs/changelogs_011.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 11-dukan
+      author: haider
+      changes:
+        - modifyColumn:
+            schemaName: dukan
+            tableName: dukans
+            columns:
+              - column:
+                  name: image_url
+                  type: varchar(255)
+                  constraints:
+                    nullable: true


### PR DESCRIPTION
## what is the PR Scope ?
Change Image url to accept nullable values in Dukan table

## why do we need that ?
we need this because we usually create dukan with null image  url 
## end points with the request and response body:
