### PR TITLE
Fix/WLT 55 Filter transactions query

### DIFF
--- a/wallet/src/main/kotlin/net/thechance/wallet/repository/TransactionRepository.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/repository/TransactionRepository.kt
@@ -28,7 +28,8 @@ interface TransactionRepository : JpaRepository<Transaction, UUID> {
             OR (
                 ('SENT' IN :transactionTypes AND t.type = 'P2P' AND t.sender.userId = :currentUserId)
                 OR ('RECEIVED' IN :transactionTypes AND t.type = 'P2P' AND t.receiver.userId = :currentUserId)
-                OR ('ONLINE_PURCHASE' IN :transactionTypes AND t.type = 'ONLINE_PURCHASE')
+                OR ('ONLINE_PURCHASE' IN :transactionTypes AND t.type = 'ONLINE_PURCHASE' AND t.sender.userId = :currentUserId)
+                OR ('RECEIVED' IN :transactionTypes AND t.type = 'ONLINE_PURCHASE' AND t.receiver.userId = :currentUserId)
             )
         )
      """


### PR DESCRIPTION
## what is the PR Scope ?
- Fix a bug in filter query related to transaction type and dukan owner.

## why do we need that ?
- When fetching transaction with type `ONLINE_PURCHASE` for a user that owns a dukan, the transactions to his dukan are returned as online purchases of his.
- When fetching received transactions for same user, the transaction received from sales on his dukan are not returned as received.
