### PR TITLE
Feature/TRN-58-add logic to know if the current user is owner of reel or not

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
@@ -2,10 +2,7 @@ package net.thechance.trends.api.controller
 
 import jakarta.validation.Valid
 import net.thechance.trends.api.dto.PagingResponse
-import net.thechance.trends.api.dto.reel.ReelResponse
-import net.thechance.trends.api.dto.reel.UpdateReelRequest
-import net.thechance.trends.api.dto.reel.UploadReelResponse
-import net.thechance.trends.api.dto.reel.toResponse
+import net.thechance.trends.api.dto.reel.*
 import net.thechance.trends.service.ReelsService
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -26,7 +23,12 @@ class ReelsController(
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<ReelResponse>> {
 
-        val reels = reelsService.getAllReelsByUserId(pageable, currentUserId).content.toResponse()
+        val reels = reelsService.getAllReelsByUserId(pageable, currentUserId).content.map { reel ->
+            reel.toResponse().withOwnership(
+                currentUserId = currentUserId,
+                ownerId = reel.ownerId
+            )
+        }
 
         val result = PagingResponse(
             pageNumber = pageable.pageNumber,

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
@@ -13,6 +13,7 @@ data class ReelResponse(
     val createdAt: LocalDateTime,
     val likesCount: Int,
     val viewsCount: Int,
+    val isCurrentUserOwner: Boolean,
     val categories: Set<Category> = emptySet()
 )
 
@@ -25,9 +26,11 @@ fun Reel.toResponse(): ReelResponse {
         createdAt = createdAt,
         likesCount = likesCount,
         viewsCount = viewsCount,
-        categories = categories
+        categories = categories,
+        isCurrentUserOwner = false
     )
 }
 
-
-fun List<Reel>.toResponse() = map { it.toResponse() }
+fun ReelResponse.withOwnership(currentUserId: UUID, ownerId: UUID): ReelResponse {
+    return this.copy(isCurrentUserOwner = currentUserId == ownerId)
+}


### PR DESCRIPTION
## what is the PR Scope ?
- Add is isCurrentUserOwner field into response 

## why do we need that ?
- To know if the current user owns the reel or not because based on that there will be different actions

## end points with the request and response body:
Endpoint ---> `trends/reels?page=1`

Response body 
```json
{
    "pageNumber": 1,
    "results": [
        {
            "reelId": "85441d0a-bcf6-4e1d-8e41-9437be6eaea5",
            "thumbnailUrl": "http://localhost.localstack.cloud:4566/thumbnail/trends/37_thumbnail.jpg_2025-10-04T19:21:52.443211300.jpg",
            "videoUrl": "http://localhost.localstack.cloud:4566/video/trends/37.mp4_2025-10-04T19:21:30.178378500.mp4",
            "description": "dsfdsgdfgdds",
            "createdAt": "2025-10-04T19:21:30.285514",
            "likesCount": 0,
            "viewsCount": 0,
            "isCurrentUserOwner": true,
            "categories": [
                {
                    "id": "16a368bd-42ff-4292-928c-1553b8c6a929",
                    "name": "Movies & TV",
                    "emoji": "🎬"
                }
            ]
        },
        {
            "reelId": "36d0cac1-1643-405e-a035-f65d79826f9a",
            "thumbnailUrl": "http://localhost.localstack.cloud:4566/thumbnail/trends/37_thumbnail.jpg_2025-10-04T17:59:37.309660800.jpg",
            "videoUrl": "http://localhost.localstack.cloud:4566/video/trends/37.mp4_2025-10-04T17:59:29.216808500.mp4",
            "description": "This is just for testing",
            "createdAt": "2025-10-04T17:59:29.59052",
            "likesCount": 0,
            "viewsCount": 0,
            "isCurrentUserOwner": true,
            "categories": [
                {
                    "id": "df3ffdc2-c548-4a33-b747-0f2cb1a9c965",
                    "name": "Technology",
                    "emoji": "💻"
                }
            ]
        }
    ],
    "totalResults": 5
}