### PR TITLE
feat: add endpoint to get all shelves by dukan ID

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanShelfController.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanShelfController.kt
@@ -6,16 +6,13 @@ import net.thechance.dukan.api.dto.DukanShelfResponse
 import net.thechance.dukan.entity.DukanShelf
 import net.thechance.dukan.mapper.toResponse
 import net.thechance.dukan.service.DukanShelfService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import org.springframework.web.bind.annotation.*
+import java.util.*
 
 @RestController
 @RequestMapping("/dukan/shelf")
@@ -52,5 +49,16 @@ class DukanShelfController(
     ): ResponseEntity<Unit> {
         dukanShelfService.deleteShelf(shelfId, userId)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/{dukanId}")
+    fun getAllShelvesByDukanId(
+        @PathVariable dukanId: UUID,
+        @PageableDefault(size = 10, page = 0)
+        pageable: Pageable
+    ): ResponseEntity<Page<DukanShelfResponse>> {
+        val shelvesPage = dukanShelfService.getAllShelvesByDukanId(dukanId, pageable)
+            .map(DukanShelf::toResponse)
+        return ResponseEntity.ok(shelvesPage)
     }
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanShelfRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanShelfRepository.kt
@@ -1,6 +1,8 @@
 package net.thechance.dukan.repository
 
 import net.thechance.dukan.entity.DukanShelf
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -9,5 +11,6 @@ import java.util.UUID
 interface DukanShelfRepository : JpaRepository<DukanShelf, UUID> {
     fun existsByTitleAndDukanId(title: String, dukanId: UUID): Boolean
     fun findAllByDukanId(dukanId: UUID): List<DukanShelf>
+    fun findAllByDukanId(dukanId: UUID, pageable: Pageable): Page<DukanShelf>
     fun findByIdAndDukanId(id: UUID, dukanId: UUID): DukanShelf?
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanShelfService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanShelfService.kt
@@ -6,6 +6,8 @@ import net.thechance.dukan.exception.ShelfNameAlreadyTakenException
 import net.thechance.dukan.exception.ShelfNotFoundException
 import net.thechance.dukan.repository.DukanProductRepository
 import net.thechance.dukan.repository.DukanShelfRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -31,7 +33,7 @@ class DukanShelfService(
     }
 
     fun deleteShelf(shelfId: UUID, ownerId: UUID) {
-        val shelf = getShelfById(shelfId,ownerId)
+        val shelf = getShelfById(shelfId, ownerId)
 
         if (dukanProductRepository.existsByShelfId(shelfId)) {
             throw ShelfDeletionNotAllowedException()
@@ -51,5 +53,9 @@ class DukanShelfService(
         val dukan = dukanService.getDukanByOwnerId(ownerId)
         return dukanShelfRepository.findByIdAndDukanId(shelfId, dukan.id)
             ?: throw ShelfNotFoundException()
+    }
+
+    fun getAllShelvesByDukanId(dukanId: UUID, pageable: Pageable): Page<DukanShelf> {
+        return dukanShelfRepository.findAllByDukanId(dukanId, pageable)
     }
 }


### PR DESCRIPTION
## what is the PR Scope ?
Implement endpoint to  get all shelves by dukan ID.

## why do we need that ?
to retrieve shelves related to a specific Dukan for management

## end points with the request and response body:

- EndPoint :-
GET
http://localhost:8080/dukan/shelf/a72cc5d4-581d-4e74-ab75-266e6ce82837?page=1&size=5

- Response :
<img width="573" height="535" alt="image" src="https://github.com/user-attachments/assets/33bc54e3-ad30-402d-a6e9-93556485df74" />
