### PR TITLE
Feature/TRN-57 trend details endpoint

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
@@ -2,10 +2,7 @@ package net.thechance.trends.api.controller
 
 import jakarta.validation.Valid
 import net.thechance.trends.api.dto.PagingResponse
-import net.thechance.trends.api.dto.reel.ReelResponse
-import net.thechance.trends.api.dto.reel.UpdateReelRequest
-import net.thechance.trends.api.dto.reel.UploadReelResponse
-import net.thechance.trends.api.dto.reel.toResponse
+import net.thechance.trends.api.dto.reel.*
 import net.thechance.trends.service.ReelsService
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -25,8 +22,12 @@ class ReelsController(
         pageable: Pageable,
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<ReelResponse>> {
-
-        val reels = reelsService.getAllReelsByUserId(pageable, currentUserId).content.toResponse()
+        val reels = reelsService.getAllReelsByUserId(pageable, currentUserId).content.map { reel ->
+            reel.toResponse().withOwnership(
+                currentUserId = currentUserId,
+                ownerId = reel.ownerId
+            )
+        }
 
         val result = PagingResponse(
             pageNumber = pageable.pageNumber,
@@ -37,12 +38,21 @@ class ReelsController(
         return ResponseEntity.ok(result)
     }
 
+    @GetMapping("/{id}")
+    fun getReelById(
+        @PathVariable id: UUID,
+        @AuthenticationPrincipal currentUserId: UUID
+    ): ResponseEntity<ReelResponse> {
+        return reelsService
+            .getReelById(id)
+            .getResponseEntity(currentUserId)
+    }
+
     @DeleteMapping("/{id}")
     fun deleteReelById(
         @PathVariable id: UUID,
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<Unit> {
-
         reelsService.deleteReelById(id, currentUserId)
         return ResponseEntity.noContent().build()
     }

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
@@ -2,6 +2,7 @@ package net.thechance.trends.api.dto.reel
 
 import net.thechance.trends.entity.Category
 import net.thechance.trends.entity.Reel
+import org.springframework.http.ResponseEntity
 import java.time.LocalDateTime
 import java.util.*
 
@@ -13,6 +14,7 @@ data class ReelResponse(
     val createdAt: LocalDateTime,
     val likesCount: Int,
     val viewsCount: Int,
+    val isCurrentUserOwner: Boolean,
     val categories: Set<Category> = emptySet()
 )
 
@@ -25,9 +27,21 @@ fun Reel.toResponse(): ReelResponse {
         createdAt = createdAt,
         likesCount = likesCount,
         viewsCount = viewsCount,
-        categories = categories
+        isCurrentUserOwner = false,
+        categories = categories,
     )
 }
 
+fun ReelResponse.withOwnership(currentUserId: UUID, ownerId: UUID): ReelResponse {
+    return this.copy(isCurrentUserOwner = currentUserId == ownerId)
+}
 
-fun List<Reel>.toResponse() = map { it.toResponse() }
+fun Reel.getResponseEntity(currentUserId: UUID): ResponseEntity<ReelResponse> {
+    return ResponseEntity.ok(
+        this.toResponse()
+            .withOwnership(
+                currentUserId = currentUserId,
+                ownerId = this.ownerId
+            )
+    )
+}

--- a/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
@@ -10,10 +10,12 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class ReelsService(
@@ -35,6 +37,12 @@ class ReelsService(
             )
         )
         return body
+    }
+
+    fun getReelById(
+        reelId: UUID
+    ): Reel {
+        return reelsRepository.findByIdOrNull(reelId) ?: throw ReelNotFoundException()
     }
 
     @Transactional


### PR DESCRIPTION
## what is the PR Scope ?
- Add get reel details by id end point for the trends feature

## why do we need that ?
- To get all the details of a certain reel when the user opens it (video URL, thumbnail, description, ...etc.)

## end points with the request and response body:
Endpoint: `GET: trends/reels/{reelId}`

Response:
```
{
  "reelId": "85441d0a-bcf6-4e1d-8e41-9437be6eaea5",
  "thumbnailUrl": "http://localhost.localstack.cloud:4566/thumbnail/trends/37_thumbnail.jpg_2025-10-04T19:21:52.443211300.jpg",
  "videoUrl": "http://localhost.localstack.cloud:4566/video/trends/37.mp4_2025-10-04T19:21:30.178378500.mp4",
  "description": "dsfdsgdfgdds",
  "createdAt": "2025-10-04T19:21:30.285514",
  "likesCount": 0,
  "viewsCount": 0,
  "isCurrentUserOwner": true,
  "categories": [
      {
        "id": "16a368bd-42ff-4292-928c-1553b8c6a929",
        "name": "Movies & TV",
        "emoji": "🎬"
      }
    ]
}
```