### PR TITLE
implement endpoint to get dukans by categoryId

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
@@ -8,7 +8,12 @@ import net.thechance.dukan.mapper.DukanLanguage
 import net.thechance.dukan.mapper.toDto
 import net.thechance.dukan.mapper.toDukanCreationParams
 import net.thechance.dukan.mapper.toDukanStyleResponse
+import net.thechance.dukan.mapper.toResponse
 import net.thechance.dukan.service.DukanService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -24,7 +29,7 @@ class DukanController(
     @GetMapping("/styles")
     fun getAllStyles(): ResponseEntity<DukanStyleResponse> {
         val styles = dukanService.getAllStyles().toDukanStyleResponse()
-       return ResponseEntity.ok(styles)
+        return ResponseEntity.ok(styles)
     }
 
     @GetMapping("/categories")
@@ -67,12 +72,20 @@ class DukanController(
         val colors = dukanService.getAllColors().map { it.toDto() }
         return ResponseEntity.ok(DukanColorResponse(colors))
     }
-    
+
     @GetMapping("/statues")
     fun getDukanStatues(
         @AuthenticationPrincipal userId: UUID,
     ): ResponseEntity<DukanStatuesResponse> {
         val dukan = dukanService.getDukanByOwnerId(userId)
         return ResponseEntity.ok(DukanStatuesResponse(dukan.name, dukan.status))
+    }
+
+    @GetMapping("/categorie/{categoryId}")
+    fun getAllByCategoryId(
+        @PathVariable("categoryId") categoryId: UUID,
+        @PageableDefault(size = 10, page = 0, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
+    ): ResponseEntity<Page<DukanResponse>> {
+        return ResponseEntity.ok(dukanService.getAllByCategoryId(categoryId, pageable).map(Dukan::toResponse))
     }
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
@@ -7,8 +7,9 @@ import net.thechance.dukan.entity.Dukan
 import net.thechance.dukan.mapper.DukanLanguage
 import net.thechance.dukan.mapper.toDto
 import net.thechance.dukan.mapper.toDukanCreationParams
-import net.thechance.dukan.mapper.toResponse
+import net.thechance.dukan.mapper.toDukanResponse
 import net.thechance.dukan.mapper.toDukanStyleResponse
+import net.thechance.dukan.mapper.toResponse
 import net.thechance.dukan.service.DukanService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -81,12 +82,12 @@ class DukanController(
         return ResponseEntity.ok(DukanStatuesResponse(dukan.name, dukan.status))
     }
 
-    @GetMapping("/categorie/{categoryId}")
+    @GetMapping("/categories/{categoryId}")
     fun getAllByCategoryId(
         @PathVariable("categoryId") categoryId: UUID,
         @PageableDefault(size = 10, page = 0, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
     ): ResponseEntity<Page<DukanResponse>> {
-        return ResponseEntity.ok(dukanService.getAllByCategoryId(categoryId, pageable).map(Dukan::toResponse))
+        return ResponseEntity.ok(dukanService.getAllByCategoryId(categoryId, pageable).map(Dukan::toDukanResponse))
     }
 
     @GetMapping("/{dukanId}")

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/dto/DukanResponse.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/dto/DukanResponse.kt
@@ -1,0 +1,9 @@
+package net.thechance.dukan.api.dto
+
+import java.util.UUID
+
+data class DukanResponse(
+    val id: UUID,
+    val name: String,
+    val imageUrl: String
+)

--- a/dukan/src/main/kotlin/net/thechance/dukan/entity/Dukan.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/entity/Dukan.kt
@@ -1,6 +1,7 @@
 package net.thechance.dukan.entity
 
 import jakarta.persistence.*
+import java.time.Instant
 import java.util.*
 
 @Table(name = "dukans", schema = "dukan")
@@ -39,7 +40,9 @@ data class Dukan(
     @Column(name = "status", nullable = false)
     val status: Status = Status.PENDING,
     @OneToMany(mappedBy = "dukan", cascade = [CascadeType.ALL])
-    val shelves: Set<DukanShelf> = emptySet()
+    val shelves: Set<DukanShelf> = emptySet(),
+    @Column(name = "createdAt")
+    val createdAt: Instant = Instant.now()
 ) {
     enum class Status {
         APPROVED,

--- a/dukan/src/main/kotlin/net/thechance/dukan/mapper/DukanResponseMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/mapper/DukanResponseMapper.kt
@@ -1,0 +1,12 @@
+package net.thechance.dukan.mapper
+
+import net.thechance.dukan.api.dto.DukanResponse
+import net.thechance.dukan.entity.Dukan
+
+fun Dukan.toResponse(): DukanResponse {
+    return DukanResponse(
+        id =  id,
+        name = name,
+        imageUrl = imageUrl.orEmpty()
+    )
+}

--- a/dukan/src/main/kotlin/net/thechance/dukan/mapper/DukanResponseMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/mapper/DukanResponseMapper.kt
@@ -3,7 +3,7 @@ package net.thechance.dukan.mapper
 import net.thechance.dukan.api.dto.DukanResponse
 import net.thechance.dukan.entity.Dukan
 
-fun Dukan.toResponse(): DukanResponse {
+fun Dukan.toDukanResponse(): DukanResponse {
     return DukanResponse(
         id =  id,
         name = name,

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -1,6 +1,8 @@
 package net.thechance.dukan.repository
 
 import net.thechance.dukan.entity.Dukan
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -10,4 +12,6 @@ interface DukanRepository : JpaRepository<Dukan, UUID> {
     fun existsByName(name: String): Boolean
     fun existsByOwnerId(ownerId: UUID): Boolean
     fun findByOwnerId(ownerId: UUID): Dukan?
+
+    fun findAllByCategoriesId(categoryId: UUID, pageable: Pageable): Page<Dukan>
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
@@ -12,6 +12,8 @@ import net.thechance.dukan.repository.DukanCategoryRepository
 import net.thechance.dukan.repository.DukanColorRepository
 import net.thechance.dukan.repository.DukanRepository
 import net.thechance.dukan.service.model.DukanCreationParams
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
@@ -67,6 +69,10 @@ class DukanService(
             )
         dukanRepository.save(dukan.copy(imageUrl = imageUrl))
         return imageUrl
+    }
+
+    fun getAllByCategoryId(categoryId: UUID, pageable: Pageable): Page<Dukan> {
+        return dukanRepository.findAllByCategoriesId(categoryId, pageable)
     }
 
     private fun validateDukanCreation(params: DukanCreationParams) {


### PR DESCRIPTION
## what is the PR Scope ?
This PR implement the logic and endpoint of getting Dukan's by category id as paged data 

## why do we need that ?
We need this cause one of the requirement is getting Dukan's under a certain category 

## end points with the request and response body:

`/dukan/categorie/10a76d2d-ef76-4baf-bd7a-170a2e602f68?size=10&sort=createdAt,desc`

The id here represent a path variable which is the category id 

Response 
```
{
    "totalElements": 1,
    "totalPages": 1,
    "first": true,
    "last": true,
    "size": 10,
    "content": [
        {
            "id": "0efe45c9-a249-41a6-87b8-eb0f46c026f4",
            "name": "Dukan",
            "imageUrl": "https://unbenignly-unhurt-anne.ngrok-free.dev/dukan-bucket/images/dukan/Dukan-Dukandukan_image.png_2025-10-04T18:48:33.137547.png"
        }
    ],
    "number": 0,
    "sort": {
        "empty": false,
        "unsorted": false,
        "sorted": true
    },
    "pageable": {
        "pageNumber": 0,
        "pageSize": 10,
        "sort": {
            "empty": false,
            "unsorted": false,
            "sorted": true
        },
        "offset": 0,
        "unpaged": false,
        "paged": true
    },
    "numberOfElements": 1,
    "empty": false
}

```