### PR TITLE
Feature/cht 65 get user endpoint

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
@@ -1,0 +1,26 @@
+package net.thechance.chat.api.controller
+
+import net.thechance.chat.service.ContactUserService
+import net.thechance.chat.service.model.UserModel
+import net.thechance.chat.service.model.toModel
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/chat/user")
+class UserController (
+    private val contactUserService: ContactUserService
+){
+
+    @GetMapping
+    fun getUserById(
+        @RequestParam id: String
+    ):  ResponseEntity<UserModel>{
+        val userId = UUID.fromString(id)
+        return ResponseEntity.ok(contactUserService.getUserById(userId).toModel())
+    }
+}

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
@@ -1,8 +1,8 @@
 package net.thechance.chat.api.controller
 
 import net.thechance.chat.service.ContactUserService
-import net.thechance.chat.service.model.UserModel
-import net.thechance.chat.service.model.toModel
+import net.thechance.chat.api.dto.UserDto
+import net.thechance.chat.api.dto.toDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,8 +19,8 @@ class UserController (
     @GetMapping
     fun getUserById(
         @RequestParam id: String
-    ):  ResponseEntity<UserModel>{
+    ):  ResponseEntity<UserDto>{
         val userId = UUID.fromString(id)
-        return ResponseEntity.ok(contactUserService.getUserById(userId).toModel())
+        return ResponseEntity.ok(contactUserService.getUserById(userId).toDto())
     }
 }

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
@@ -1,14 +1,14 @@
 package net.thechance.chat.api.controller
 
-import net.thechance.chat.service.ContactUserService
 import net.thechance.chat.api.dto.UserDto
 import net.thechance.chat.api.dto.toDto
+import net.thechance.chat.service.ContactUserService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
 @RestController
 @RequestMapping("/chat/user")
@@ -18,9 +18,8 @@ class UserController (
 
     @GetMapping
     fun getUserById(
-        @RequestParam id: String
+        @AuthenticationPrincipal userId : UUID
     ):  ResponseEntity<UserDto>{
-        val userId = UUID.fromString(id)
         return ResponseEntity.ok(contactUserService.getUserById(userId).toDto())
     }
 }

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/UserDto.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/UserDto.kt
@@ -1,16 +1,16 @@
-package net.thechance.chat.service.model
+package net.thechance.chat.api.dto
 
 import net.thechance.chat.entity.ContactUser
 
-data class UserModel(
+data class UserDto(
     val firstName: String,
     val lastName: String,
     val phoneNumber: String,
     val imageUrl: String? = null,
 )
 
-fun ContactUser.toModel(): UserModel{
-    return UserModel(
+fun ContactUser.toDto(): UserDto{
+    return UserDto(
         firstName = this.firstName,
         lastName = this.lastName,
         phoneNumber = this.phoneNumber,

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/UserModel.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/UserModel.kt
@@ -1,0 +1,19 @@
+package net.thechance.chat.service.model
+
+import net.thechance.chat.entity.ContactUser
+
+data class UserModel(
+    val firstName: String,
+    val lastName: String,
+    val phoneNumber: String,
+    val imageUrl: String? = null,
+)
+
+fun ContactUser.toModel(): UserModel{
+    return UserModel(
+        firstName = this.firstName,
+        lastName = this.lastName,
+        phoneNumber = this.phoneNumber,
+        imageUrl = this.imageUrl
+    )
+}

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
@@ -20,7 +20,7 @@ class UserControllerTest {
         val id = UUID.fromString(userId)
         every { contactUserService.getUserById(id) } returns contactUser
 
-        assertThat(controller.getUserById(userId).body).isEqualTo(user)
+        assertThat(controller.getUserById(id).body).isEqualTo(user)
 
     }
 
@@ -30,7 +30,7 @@ class UserControllerTest {
         every { contactUserService.getUserById(id) } throws IllegalArgumentException("User not found")
 
         assertThrows<IllegalArgumentException> {
-            controller.getUserById(invalidUserId)
+            controller.getUserById(id)
         }
     }
 
@@ -45,7 +45,7 @@ class UserControllerTest {
             imageUrl = null
         )
         val contactUser= ContactUser(
-            id = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6"),
+            id = UUID.fromString(userId),
             firstName = "omer",
             lastName = "faris",
             phoneNumber = "+9647710222244",

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
@@ -1,0 +1,55 @@
+package net.thechance.chat.api.controller
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import net.thechance.chat.entity.ContactUser
+import net.thechance.chat.service.ContactUserService
+import net.thechance.chat.service.model.UserModel
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+import kotlin.test.Test
+
+class UserControllerTest {
+
+    private val contactUserService: ContactUserService = mockk()
+    private val controller by lazy { UserController(contactUserService) }
+
+    @Test
+    fun `should get user information when getUserById succeeded`(){
+        val id = UUID.fromString(userId)
+        every { contactUserService.getUserById(id) } returns contactUser
+
+        assertThat(controller.getUserById(userId).body).isEqualTo(user)
+
+    }
+
+    @Test
+    fun `should throw exception when getUserById throws exception`() {
+        val id = UUID.fromString(invalidUserId)
+        every { contactUserService.getUserById(id) } throws IllegalArgumentException("User not found")
+
+        assertThrows<IllegalArgumentException> {
+            controller.getUserById(invalidUserId)
+        }
+    }
+
+
+    companion object{
+        val userId = "451e4d6c-0380-41ed-95e6-275793c404c6"
+        val invalidUserId = "451e4d6c-0380-41ed-95e6-275793c404c8"
+        val user = UserModel(
+            firstName = "omer",
+            lastName = "faris",
+            phoneNumber = "+9647710222244",
+            imageUrl = null
+        )
+        val contactUser= ContactUser(
+            id = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6"),
+            firstName = "omer",
+            lastName = "faris",
+            phoneNumber = "+9647710222244",
+            imageUrl = null
+        )
+    }
+}

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/UserControllerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import net.thechance.chat.entity.ContactUser
 import net.thechance.chat.service.ContactUserService
-import net.thechance.chat.service.model.UserModel
+import net.thechance.chat.api.dto.UserDto
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 import kotlin.test.Test
@@ -38,7 +38,7 @@ class UserControllerTest {
     companion object{
         val userId = "451e4d6c-0380-41ed-95e6-275793c404c6"
         val invalidUserId = "451e4d6c-0380-41ed-95e6-275793c404c8"
-        val user = UserModel(
+        val user = UserDto(
             firstName = "omer",
             lastName = "faris",
             phoneNumber = "+9647710222244",


### PR DESCRIPTION
## what is the PR Scope ?
add endpoint to get the data of the user 

## why do we need that ?
in order to display the data in required section

## end points with the request and response body:
endpoint: chat/user
```
{
    "firstName": "osama",
    "lastName": "kamel",
    "phoneNumber": "+967775074564",
    "imageUrl": null
}
```