### PR TITLE
feature/DKN-75-editors-pick-endpoint

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/controller/DukanController.kt
@@ -90,6 +90,18 @@ class DukanController(
         return ResponseEntity.ok(dukanService.getAllByCategoryId(categoryId, pageable).map(Dukan::toDukanResponse))
     }
 
+
+    @GetMapping("/editor_picks")
+    fun getEditorPicksDukan(
+        @AuthenticationPrincipal userId: UUID?,
+        @PageableDefault(size = 5, page = 0, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable
+    ): ResponseEntity<Page<DukanResponse>> {
+        val dukansPage = dukanService.getAllEditorPicksDukan(userId, pageable)
+        return ResponseEntity.ok(dukansPage.map(Dukan::toDukanResponse))
+    }
+
+
     @GetMapping("/{dukanId}")
     fun getDukanDetailsById(@PathVariable("dukanId") dukanId: UUID): ResponseEntity<DukanDetailsResponse> {
         val dukanDetails = dukanService.getDukanDetailsById(dukanId).toResponse()

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -4,6 +4,7 @@ import net.thechance.dukan.entity.Dukan
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -11,7 +12,25 @@ import java.util.UUID
 interface DukanRepository : JpaRepository<Dukan, UUID> {
     fun existsByName(name: String): Boolean
     fun existsByOwnerId(ownerId: UUID): Boolean
-    fun findByOwnerId(ownerId: UUID): Dukan?
-
+    fun findByOwnerId(ownerId: UUID): Dukan
     fun findAllByCategoriesId(categoryId: UUID, pageable: Pageable): Page<Dukan>
+    @Query(
+        """
+    SELECT DISTINCT d
+    FROM Dukan d
+    WHERE d.status = net.thechance.dukan.entity.Dukan.Status.APPROVED
+    AND EXISTS (
+        SELECT s FROM DukanShelf s
+        WHERE s.dukan = d
+    )
+    AND EXISTS (
+        SELECT p FROM DukanProduct p
+        WHERE p.dukan = d
+    )
+    ORDER BY d.createdAt DESC
+    """
+    )
+    fun findAllApprovedWithShelvesAndProducts(pageable: Pageable): Page<Dukan>
+
+
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -20,11 +20,13 @@ interface DukanRepository : JpaRepository<Dukan, UUID> {
     FROM Dukan d
     WHERE d.status = net.thechance.dukan.entity.Dukan.Status.APPROVED
     AND EXISTS (
-        SELECT s FROM DukanShelf s
+        SELECT 1 
+        FROM DukanShelf s
         WHERE s.dukan = d
     )
     AND EXISTS (
-        SELECT p FROM DukanProduct p
+        SELECT 1
+        FROM DukanProduct p
         WHERE p.dukan = d
     )
     ORDER BY d.createdAt DESC

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
@@ -80,6 +80,11 @@ class DukanService(
         return dukanRepository.findAllByCategoriesId(categoryId, pageable)
     }
 
+    fun getAllEditorPicksDukan(userId: UUID?, pageable: Pageable): Page<Dukan> {
+        // TODO: Filter by user preferences once data model is ready
+        return dukanRepository.findAllApprovedWithShelvesAndProducts(pageable)
+    }
+
     private fun validateDukanCreation(params: DukanCreationParams) {
         if (dukanRepository.existsByOwnerId(params.ownerId)) {
             throw DukanCreationFailedException()


### PR DESCRIPTION
## what is the PR Scope ?
dukan end points implementation 

## why do we need that ?

wee need an end point to return editor picks dukans pages but since we don;t have user preferences in the db right now we are returning all the valide dukans with at least on shelf and on product in it 
## end points with the request and response body:
request : http://localhost:8080/dukan/editor_picks
response:
'''

{
  "totalElements": 2,
  "totalPages": 1,
  "first": true,
  "last": true,
  "size": 5,
  "content": [
    {
      "id": "22222222-2222-2222-2222-222222222222",
      "name": "My Test Dukan",
      "imageUrl": "https://picsum.photos/200/200?random=99"
    },
    {
      "id": "ca64095d-4e53-426d-bdc7-cff205b743a4",
      "name": "Demo Dukan",
      "imageUrl": "https://picsum.photos/200/200"
    }
  ],
  "number": 0,
  "sort": {
    "empty": false,
    "unsorted": false,
    "sorted": true
  },
  "pageable": {
    "pageNumber": 0,
    "pageSize": 5,
    "sort": {
      "empty": false,
      "unsorted": false,
      "sorted": true
    },
    "offset": 0,
    "unpaged": false,
    "paged": true
  },
  "numberOfElements": 2,
  "empty": false
}
'''