### PR TITLE
Feature: TRN-69 Get User Reel Categories

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
@@ -1,7 +1,7 @@
 package net.thechance.trends.api.controller
 
 import jakarta.validation.Valid
-import net.thechance.trends.api.dto.category.GetAllCategoriesResponse
+import net.thechance.trends.api.dto.category.CategoryResponse
 import net.thechance.trends.api.dto.category.SubmitUserCategoriesRequest
 import net.thechance.trends.api.dto.category.SubmitUserCategoriesResponse
 import net.thechance.trends.api.dto.category.toCategoryResponse
@@ -9,12 +9,8 @@ import net.thechance.trends.service.CategoryService
 import net.thechance.trends.service.TrendUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import org.springframework.web.bind.annotation.*
+import java.util.*
 
 @RestController
 @RequestMapping("/${Constants.TRENDS_PATH}/categories")
@@ -38,12 +34,16 @@ class CategoryController(
     }
 
     @GetMapping
-    fun getAllCategories(): ResponseEntity<GetAllCategoriesResponse> {
-        val categories = categoryService.getAllCategories()
-        val response = GetAllCategoriesResponse(
-            message = "Success",
-            data = categories.map { it.toCategoryResponse() }
+    fun getSelectedCategories(
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<List<CategoryResponse>> {
+        val allCategories = categoryService.getAllCategories()
+        val userCategories = trendUserService.getUserSelectedCategories(userId)
+
+        return ResponseEntity.ok(
+            allCategories.map {
+                it.toCategoryResponse(isSelected = it in userCategories)
+            }
         )
-        return ResponseEntity.ok(response)
     }
 }

--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
@@ -41,8 +41,8 @@ class CategoryController(
         val userCategories = trendUserService.getUserSelectedCategories(userId)
 
         return ResponseEntity.ok(
-            allCategories.map {
-                it.toCategoryResponse(isSelected = it in userCategories)
+            allCategories.map { category ->
+                category.toCategoryResponse(isSelected = category in userCategories)
             }
         )
     }

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/CategoryResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/CategoryResponse.kt
@@ -1,18 +1,22 @@
 package net.thechance.trends.api.dto.category
 
 import net.thechance.trends.entity.Category
-import java.util.UUID
+import java.util.*
 
 data class CategoryResponse(
     val id: UUID,
     val name: String,
-    val emoji: String
+    val emoji: String,
+    val isSelected: Boolean
 )
 
-fun Category.toCategoryResponse(): CategoryResponse {
+fun Category.toCategoryResponse(
+    isSelected: Boolean
+): CategoryResponse {
     return CategoryResponse(
         id = this.id,
         name = this.name,
-        emoji = this.emoji
+        emoji = this.emoji,
+        isSelected = isSelected
     )
 }

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/GetAllCategoriesResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/GetAllCategoriesResponse.kt
@@ -1,6 +1,0 @@
-package net.thechance.trends.api.dto.category
-
-data class GetAllCategoriesResponse(
-    val message: String,
-    val data: List<CategoryResponse>
-)

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -1,13 +1,14 @@
 package net.thechance.trends.service
 
+import net.thechance.trends.entity.Category
+import net.thechance.trends.entity.TrendUser
 import net.thechance.trends.exception.InvalidTrendInputException
 import net.thechance.trends.exception.TrendCategoryNotFoundException
-import net.thechance.trends.entity.TrendUser
 import net.thechance.trends.repository.CategoryRepository
 import net.thechance.trends.repository.TrendUserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
+import java.util.*
 import kotlin.jvm.optionals.getOrElse
 import kotlin.jvm.optionals.getOrNull
 
@@ -39,6 +40,10 @@ class TrendUserService(
         val updatedUser = trendUser.copy(categories = categoryProxies)
         trendUserRepository.save(updatedUser)
 
+    }
+
+    fun getUserSelectedCategories(userId: UUID): Set<Category> {
+        return trendUserRepository.findById(userId).getOrNull()?.categories ?: emptySet()
     }
 
     fun getDoesUserHaveCategories(userId: UUID): Boolean {

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -43,7 +43,7 @@ class TrendUserService(
     }
 
     fun getUserSelectedCategories(userId: UUID): Set<Category> {
-        return trendUserRepository.findById(userId).getOrNull()?.categories ?: emptySet()
+        return trendUserRepository.findById(userId).getOrNull()?.categories.orEmpty()
     }
 
     fun getDoesUserHaveCategories(userId: UUID): Boolean {


### PR DESCRIPTION
## What is the PR Scope?

This PR modifies the categories endpoint to return user-specific category selection status. The changes include:

- Updated `CategoryController` to return categories with user selection status
- Enhanced `CategoryResponse` to include `isSelected` field
- Removed `GetAllCategoriesResponse` wrapper DTO
- Added service method to fetch user's selected categories

## Why do we need that?

The previous implementation returned all categories without indicating which ones the user had selected. This required clients to make additional API calls to determine the user's category preferences. By including the selection status directly in the categories response, we:

- Reduce the number of API calls needed
- Simplify client-side logic for displaying categories
- Provide a more efficient way to show which categories are selected by the user

## End points with the request and response body:

**Endpoint:** `GET /trends/categories`

**Request Headers:**
- Authentication: Bearer token required

**Response Body:**
```json
[
  {
    "id": "c8aac40e-74ff-4240-b6eb-6bbac7bcc27c",
    "name": "Technology",
    "emoji": "💻",
    "isSelected": true
  },
  {
    "id": "1c0e34d9-737d-4003-a9dc-2c7ad14a9ca6",
    "name": "Sports",
    "emoji": "⚽",
    "isSelected": true
  },
  {
    "id": "e878f644-564c-45f7-ac95-e728567a7962",
    "name": "Music",
    "emoji": "🎵",
    "isSelected": true
  },
  {
    "id": "7d23f8c4-6107-4b22-868e-749ece4a115f",
    "name": "Movies & TV",
    "emoji": "🎬",
    "isSelected": true
  },
  {
    "id": "5d271f35-a357-4371-873a-b9d59cf180ab",
    "name": "Gaming",
    "emoji": "🎮",
    "isSelected": false
  },
  {
    "id": "d68b4ea7-df59-4265-ac9b-8f1e8fb8cd21",
    "name": "Travel",
    "emoji": "✈️",
    "isSelected": false
  }
]