### PR TITLE
fix getting only approved dukans with products by category

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -13,7 +13,30 @@ interface DukanRepository : JpaRepository<Dukan, UUID> {
     fun existsByName(name: String): Boolean
     fun existsByOwnerId(ownerId: UUID): Boolean
     fun findByOwnerId(ownerId: UUID): Dukan
-    fun findAllByCategoriesId(categoryId: UUID, pageable: Pageable): Page<Dukan>
+    @Query(
+        """
+    SELECT DISTINCT d
+    FROM Dukan d
+    JOIN d.categories c
+    WHERE d.status = net.thechance.dukan.entity.Dukan.Status.APPROVED
+      AND c.id = :categoryId
+      AND EXISTS (
+          SELECT 1 
+          FROM DukanShelf s
+          WHERE s.dukan = d
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM DukanProduct p
+          WHERE p.dukan = d
+      )
+    ORDER BY d.createdAt DESC
+    """
+    )
+    fun findApprovedDukansWithProductsByCategory(
+        categoryId: UUID,
+        pageable: Pageable
+    ): Page<Dukan>
     @Query(
         """
     SELECT DISTINCT d

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanService.kt
@@ -77,7 +77,7 @@ class DukanService(
     }
 
     fun getAllByCategoryId(categoryId: UUID, pageable: Pageable): Page<Dukan> {
-        return dukanRepository.findAllByCategoriesId(categoryId, pageable)
+        return dukanRepository.findApprovedDukansWithProductsByCategory(categoryId, pageable)
     }
 
     fun getAllEditorPicksDukan(userId: UUID?, pageable: Pageable): Page<Dukan> {


### PR DESCRIPTION
## what is the PR Scope ?
 fix a problem getting dukans by category 

## why do we need that ?
we used to getting all dukans by category while we should get only approved dukans with products 
## end points with the request and response body:
