### PR TITLE
Feature/cht 69 get chat by id endpoint

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
@@ -76,6 +76,21 @@ class ChatController(
         )
     }
 
+    @GetMapping("/{chatId}")
+    fun getChatDetail(
+        @PathVariable chatId : String,
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<ChatResponse>{
+        val id = UUID.fromString(chatId)
+        val chat = chatService.getChatById(id) ?: throw IllegalStateException("chat not found")
+        val otherUser = chat.users.firstOrNull { it.id != userId }
+        val contact =otherUser?.let{
+            contactService.getContactByOwnerIdAndContactUserId(userId, it.id)
+        }
+        return ResponseEntity.ok(chat.toResponse(userId,contact))
+
+    }
+
     companion object {
         const val QUEUE_MESSAGES = "/queue/messages"
     }

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
@@ -3,7 +3,6 @@ package net.thechance.chat.api.controller
 import net.thechance.chat.api.dto.*
 import net.thechance.chat.service.ChatService
 import net.thechance.chat.service.ContactService
-import net.thechance.chat.service.model.toResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.MessageMapping

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
@@ -3,6 +3,7 @@ package net.thechance.chat.api.controller
 import net.thechance.chat.api.dto.*
 import net.thechance.chat.service.ChatService
 import net.thechance.chat.service.ContactService
+import net.thechance.chat.service.model.toResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -78,17 +79,11 @@ class ChatController(
 
     @GetMapping("/{chatId}")
     fun getChatDetail(
-        @PathVariable chatId : String,
+        @PathVariable chatId : UUID,
         @AuthenticationPrincipal userId: UUID
     ): ResponseEntity<ChatResponse>{
-        val id = UUID.fromString(chatId)
-        val chat = chatService.getChatById(id) ?: throw IllegalStateException("chat not found")
-        val otherUser = chat.users.firstOrNull { it.id != userId }
-        val contact =otherUser?.let{
-            contactService.getContactByOwnerIdAndContactUserId(userId, it.id)
-        }
-        return ResponseEntity.ok(chat.toResponse(userId,contact))
-
+       val chat = chatService.getChatById(chatId, userId)
+        return ResponseEntity.ok(chat.toResponse())
     }
 
     companion object {

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ErrorHandler.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ErrorHandler.kt
@@ -1,0 +1,23 @@
+package net.thechance.chat.api.controller
+
+import net.thechance.chat.api.dto.ErrorResponse
+import net.thechance.chat.service.exception.NotFoundException
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+@RestControllerAdvice
+@Order(1)
+class ChatControllerAdvice : ResponseEntityExceptionHandler() {
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
+        val error = ErrorResponse(e.message ?: "Resource not found")
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(error)
+    }
+}

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/ChatResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/ChatResponse.kt
@@ -3,6 +3,7 @@ package net.thechance.chat.api.dto
 import net.thechance.chat.entity.Chat
 import net.thechance.chat.entity.Contact
 import net.thechance.chat.entity.ContactUser
+import net.thechance.chat.service.model.ChatModel
 import java.util.UUID
 
 data class ChatResponse(
@@ -27,4 +28,12 @@ private fun getChatName(contact: Contact?, theOtherUser: ContactUser?): String {
         ?: theOtherUser?.let { "${it.firstName} ${it.lastName}" }.orEmpty()
 }
 
+fun ChatModel.toResponse(): ChatResponse{
+    return ChatResponse(
+        id = id,
+        name = name,
+        requesterId = requesterId,
+        imageUrl = imageUrl
+    )
+}
 

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/ErrorResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/ErrorResponse.kt
@@ -1,0 +1,5 @@
+package net.thechance.chat.api.dto
+
+data class ErrorResponse(
+    val message : String
+)

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -2,10 +2,14 @@ package net.thechance.chat.service
 
 import jakarta.persistence.EntityManager
 import net.thechance.chat.entity.Chat
+import net.thechance.chat.entity.Contact
+import net.thechance.chat.entity.ContactUser
 import net.thechance.chat.entity.Message
 import net.thechance.chat.repository.ChatRepository
 import net.thechance.chat.repository.MessageRepository
 import net.thechance.chat.service.args.CreateMessageArgs
+import net.thechance.chat.service.exception.NotFoundException
+import net.thechance.chat.service.model.ChatModel
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -17,6 +21,7 @@ class ChatService(
     private val messageRepository: MessageRepository,
     private val chatRepository: ChatRepository,
     private val contactUserService: ContactUserService,
+    private val contactService: ContactService,
     private val entityManager: EntityManager
 ) {
     @Transactional
@@ -52,8 +57,23 @@ class ChatService(
     fun markChatMessagesAsRead(chatId: UUID, userId: UUID) =
         messageRepository.updateIsReadByChatIdAndSenderIdNot(chatId = chatId, userId = userId)
 
-    fun getChatById(chatId: UUID): Chat?{
-        return chatRepository.findByIdOrNull(chatId)
+    fun getChatById(chatId: UUID, userId: UUID): ChatModel {
+        val chat = chatRepository.findByIdOrNull(chatId) ?: throw NotFoundException("no chat was found with id: $chatId")
+        val otherUser = chat.users.firstOrNull { it.id != userId }
+        val contact =otherUser?.let{
+            contactService.getContactByOwnerIdAndContactUserId(userId, it.id)
+        }
+        return ChatModel(
+            name = getChatName(contact, otherUser),
+            imageUrl = otherUser?.imageUrl,
+            requesterId = userId,
+            id = chatId
+        )
+    }
+
+    private fun getChatName(contact: Contact?, user: ContactUser? ): String{
+        return contact?.let { "${it.firstName} ${it.lastName}" }
+            ?: user?.let { "${it.firstName} ${it.lastName}" }.orEmpty()
     }
 
 }

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -53,8 +53,7 @@ class ChatService(
         messageRepository.updateIsReadByChatIdAndSenderIdNot(chatId = chatId, userId = userId)
 
     fun getChatById(chatId: UUID): Chat?{
-        val chat = chatRepository.findByIdOrNull(chatId)
-        return chat
+        return chatRepository.findByIdOrNull(chatId)
     }
 
 }

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -7,6 +7,7 @@ import net.thechance.chat.repository.ChatRepository
 import net.thechance.chat.repository.MessageRepository
 import net.thechance.chat.service.args.CreateMessageArgs
 import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -50,4 +51,10 @@ class ChatService(
 
     fun markChatMessagesAsRead(chatId: UUID, userId: UUID) =
         messageRepository.updateIsReadByChatIdAndSenderIdNot(chatId = chatId, userId = userId)
+
+    fun getChatById(chatId: UUID): Chat?{
+        val chat = chatRepository.findByIdOrNull(chatId)
+        return chat
+    }
+
 }

--- a/chat/src/main/kotlin/net/thechance/chat/service/exception/ChatException.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/exception/ChatException.kt
@@ -1,0 +1,3 @@
+package net.thechance.chat.service.exception
+
+class NotFoundException(message: String) : RuntimeException(message)

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
@@ -1,6 +1,5 @@
 package net.thechance.chat.service.model
 
-import net.thechance.chat.api.dto.ChatResponse
 import java.util.UUID
 
 data class ChatModel (
@@ -9,12 +8,3 @@ data class ChatModel (
     val requesterId : UUID,
     val id: UUID,
     )
-
-fun ChatModel.toResponse(): ChatResponse{
-    return ChatResponse(
-        id = id,
-        name = name,
-        requesterId = requesterId,
-        imageUrl = imageUrl
-    )
-}

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
@@ -1,0 +1,20 @@
+package net.thechance.chat.service.model
+
+import net.thechance.chat.api.dto.ChatResponse
+import java.util.UUID
+
+data class ChatModel (
+    val name : String,
+    val imageUrl : String?,
+    val requesterId : UUID,
+    val id: UUID,
+    )
+
+fun ChatModel.toResponse(): ChatResponse{
+    return ChatResponse(
+        id = id,
+        name = name,
+        requesterId = requesterId,
+        imageUrl = imageUrl
+    )
+}

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
@@ -6,6 +6,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import net.thechance.chat.api.controller.ChatController.Companion.QUEUE_MESSAGES
+import net.thechance.chat.api.dto.ChatResponse
 import net.thechance.chat.api.dto.MarkAsReadRequest
 import net.thechance.chat.api.dto.MarkAsReadResponse
 import net.thechance.chat.api.dto.MessageRequestDto
@@ -16,6 +17,7 @@ import net.thechance.chat.entity.Message
 import net.thechance.chat.service.ChatService
 import net.thechance.chat.service.ContactService
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -137,5 +139,88 @@ class ChatControllerTest {
             )
         }
         verify { chatService.markChatMessagesAsRead(chatId, userId) }
+    }
+
+    @Test
+    fun `getChatDetail should get chatResponse correctly when specific chat exist`() {
+        every { chatService.getChatById(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
+
+        val result = controller.getChatDetail(chatIdString, userId).body
+
+        assertThat(result).isEqualTo(chatResponse)
+    }
+
+    @Test
+    fun `getChatDetail should return chat name equal to other contact names when the other user is in our contact list`() {
+        every { chatService.getChatById(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
+
+        val result = controller.getChatDetail(chatIdString, userId).body
+
+        assertThat(result?.name).isEqualTo("${contact.firstName} ${contact.lastName}")
+    }
+
+    @Test
+    fun `getChatDetail should return chat name equal to other mina user names when the other user is not in our contact list`() {
+        every { chatService.getChatById(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
+
+        val result = controller.getChatDetail(chatIdString, userId).body
+
+        assertThat(result?.name).isEqualTo("${otherUser.firstName} ${otherUser.lastName}")
+    }
+
+    @Test
+    fun `getChatDetail should throw IllegalStateException when there is no chat available with specific chat id `() {
+        every { chatService.getChatById(notAvailableChatId) } returns null
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
+
+        assertThrows<IllegalStateException> {
+            controller.getChatDetail(notAvailableChatIdString, userId)
+        }
+    }
+
+    private companion object {
+        val chatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-16ba3869610e")
+        val chatIdString = "825265f7-7e30-4ac3-b9fb-16ba3869610e"
+
+        val notAvailableChatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-87ba3869610e")
+        val notAvailableChatIdString = "825265f7-7e30-4ac3-b9fb-87ba3869610e"
+
+        val userId = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6")
+
+        val contact = Contact(
+            id = UUID.fromString("73439a0a-adfa-4bf7-86ad-0d66435d5f18"),
+            firstName = "Raouf",
+            lastName = "kamel",
+            phoneNumber = "+967775074564",
+            contactOwnerId = userId
+        )
+        val otherUser = ContactUser(
+            id = UUID.fromString("1804d9db-c870-421d-934b-b00528cb5b93"),
+            firstName = "osama",
+            lastName = "kamel",
+            phoneNumber = "+967775074564",
+            imageUrl = null
+        )
+        val meUser = ContactUser(
+            id = userId,
+            firstName = "omer",
+            lastName = "faris",
+            phoneNumber = "9647844440001",
+            imageUrl = null
+        )
+        val chatResponse = ChatResponse(
+            id = chatId,
+            name = "Raouf kamel",
+            requesterId = userId,
+            imageUrl = null
+        )
+
+        val chat = Chat(
+            id = chatId,
+            users = mutableSetOf(meUser, otherUser),
+        )
     }
 }

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
@@ -16,6 +16,8 @@ import net.thechance.chat.entity.ContactUser
 import net.thechance.chat.entity.Message
 import net.thechance.chat.service.ChatService
 import net.thechance.chat.service.ContactService
+import net.thechance.chat.service.exception.NotFoundException
+import net.thechance.chat.service.model.ChatModel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageImpl
@@ -142,85 +144,37 @@ class ChatControllerTest {
     }
 
     @Test
-    fun `getChatDetail should get chatResponse correctly when specific chat exist`() {
-        every { chatService.getChatById(chatId) } returns chat
-        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
-
-        val result = controller.getChatDetail(chatIdString, userId).body
+    fun `getChatDetail should get chat response correctly when the function run successfully `(){
+        every {chatService.getChatById(chatId, userId)} returns chatModel
+        val result = controller.getChatDetail(chatId, userId).body
 
         assertThat(result).isEqualTo(chatResponse)
     }
 
     @Test
-    fun `getChatDetail should return chat name equal to other contact names when the other user is in our contact list`() {
-        every { chatService.getChatById(chatId) } returns chat
-        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
-
-        val result = controller.getChatDetail(chatIdString, userId).body
-
-        assertThat(result?.name).isEqualTo("${contact.firstName} ${contact.lastName}")
-    }
-
-    @Test
-    fun `getChatDetail should return chat name equal to other mina user names when the other user is not in our contact list`() {
-        every { chatService.getChatById(chatId) } returns chat
-        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
-
-        val result = controller.getChatDetail(chatIdString, userId).body
-
-        assertThat(result?.name).isEqualTo("${otherUser.firstName} ${otherUser.lastName}")
-    }
-
-    @Test
-    fun `getChatDetail should throw IllegalStateException when there is no chat available with specific chat id `() {
-        every { chatService.getChatById(notAvailableChatId) } returns null
-        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
-
-        assertThrows<IllegalStateException> {
-            controller.getChatDetail(notAvailableChatIdString, userId)
+    fun `getChatDetail should throw not found exception when try to find unavailable chatId`(){
+        every {chatService.getChatById(chatId, userId)} throws NotFoundException("")
+        assertThrows<NotFoundException> {
+            controller.getChatDetail(chatId = chatId, userId = userId)
         }
     }
 
-    private companion object {
+    private companion object{
         val chatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-16ba3869610e")
-        val chatIdString = "825265f7-7e30-4ac3-b9fb-16ba3869610e"
-
-        val notAvailableChatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-87ba3869610e")
-        val notAvailableChatIdString = "825265f7-7e30-4ac3-b9fb-87ba3869610e"
-
         val userId = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6")
 
-        val contact = Contact(
-            id = UUID.fromString("73439a0a-adfa-4bf7-86ad-0d66435d5f18"),
-            firstName = "Raouf",
-            lastName = "kamel",
-            phoneNumber = "+967775074564",
-            contactOwnerId = userId
-        )
-        val otherUser = ContactUser(
-            id = UUID.fromString("1804d9db-c870-421d-934b-b00528cb5b93"),
-            firstName = "osama",
-            lastName = "kamel",
-            phoneNumber = "+967775074564",
-            imageUrl = null
-        )
-        val meUser = ContactUser(
-            id = userId,
-            firstName = "omer",
-            lastName = "faris",
-            phoneNumber = "9647844440001",
-            imageUrl = null
-        )
-        val chatResponse = ChatResponse(
-            id = chatId,
+        val chatModel = ChatModel(
             name = "Raouf kamel",
+            imageUrl = null,
             requesterId = userId,
-            imageUrl = null
+            id = chatId
         )
 
-        val chat = Chat(
-            id = chatId,
-            users = mutableSetOf(meUser, otherUser),
+        val chatResponse = ChatResponse(
+            name = "Raouf kamel",
+            imageUrl = null,
+            requesterId = userId,
+            id = chatId
         )
     }
 }

--- a/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
@@ -7,13 +7,17 @@ import io.mockk.verify
 import jakarta.persistence.EntityManager
 import jakarta.persistence.EntityNotFoundException
 import net.thechance.chat.entity.Chat
+import net.thechance.chat.entity.Contact
 import net.thechance.chat.entity.ContactUser
 import net.thechance.chat.repository.ChatRepository
 import net.thechance.chat.repository.MessageRepository
 import net.thechance.chat.service.args.CreateMessageArgs
+import net.thechance.chat.service.exception.NotFoundException
+import net.thechance.chat.service.model.ChatModel
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.repository.findByIdOrNull
 import java.time.Instant
 import java.util.*
 
@@ -22,6 +26,7 @@ class ChatServiceTest {
     private lateinit var messageRepository: MessageRepository
     private lateinit var chatRepository: ChatRepository
     private lateinit var contactUserService: ContactUserService
+    private lateinit var contactService: ContactService
     private lateinit var entityManager: EntityManager
     private lateinit var service: ChatService
 
@@ -44,7 +49,8 @@ class ChatServiceTest {
         chatRepository = mockk(relaxed = true)
         contactUserService = mockk(relaxed = true)
         entityManager = mockk(relaxed = true)
-        service = ChatService(messageRepository, chatRepository, contactUserService, entityManager)
+        contactService = mockk()
+        service = ChatService(messageRepository, chatRepository, contactUserService,contactService, entityManager)
     }
 
     @Test
@@ -136,5 +142,81 @@ class ChatServiceTest {
         service.markChatMessagesAsRead(chatId, userId)
 
         verify { messageRepository.updateIsReadByChatIdAndSenderIdNot(chatId, userId) }
+    }
+
+    @Test
+    fun `getChatById should get chatModel correctly when specific chat exist`() {
+        every { chatRepository.findByIdOrNull(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
+        val result = service.getChatById(chatId, userId)
+        assertThat(result).isEqualTo(chatModel)
+    }
+
+    @Test
+    fun `getChatById should return chat name equal to other contact names when the other user is in our contact list`() {
+        every { chatRepository.findByIdOrNull(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
+        val result = service.getChatById(chatId, userId)
+
+        assertThat(result.name).isEqualTo("${contact.firstName} ${contact.lastName}")
+    }
+
+    @Test
+    fun `getChatById should return chat name equal to other mina user names when the other user is not in our contact list`() {
+        every { chatRepository.findByIdOrNull(chatId) } returns chat
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
+        val result = service.getChatById(chatId, userId)
+
+        assertThat(result.name).isEqualTo("${otherUser.firstName} ${otherUser.lastName}")
+    }
+
+    @Test
+    fun `getChatById should throw NotFoundException when there is no chat available with specific chat id `() {
+        every { chatRepository.findByIdOrNull(notAvailableChatId) } returns null
+        every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns null
+
+        assertThrows<NotFoundException> {
+            service.getChatById(notAvailableChatId, userId)
+        }
+    }
+
+    private companion object {
+        val chatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-16ba3869610e")
+        val userId = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6")
+        val notAvailableChatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-87ba3869610e")
+
+        val contact = Contact(
+            id = UUID.fromString("73439a0a-adfa-4bf7-86ad-0d66435d5f18"),
+            firstName = "Raouf",
+            lastName = "kamel",
+            phoneNumber = "+967775074564",
+            contactOwnerId = userId
+        )
+        val otherUser = ContactUser(
+            id = UUID.fromString("1804d9db-c870-421d-934b-b00528cb5b93"),
+            firstName = "osama",
+            lastName = "kamel",
+            phoneNumber = "+967775074564",
+            imageUrl = null
+        )
+        val meUser = ContactUser(
+            id = userId,
+            firstName = "omer",
+            lastName = "faris",
+            phoneNumber = "9647844440001",
+            imageUrl = null
+        )
+
+        val chatModel = ChatModel(
+            name = "Raouf kamel",
+            imageUrl = null,
+            requesterId = userId,
+            id = chatId
+        )
+
+        val chat = Chat(
+            id = chatId,
+            users = mutableSetOf(meUser, otherUser),
+        )
     }
 }


### PR DESCRIPTION
## what is the PR Scope ?
implement getting specific chat detail based on specific chat id

## why do we need that ?
in order to get some information about specific chat like chat name, imageUrl.

## end points with the request and response body:
"chat/{chatId}"

```
{
    "id": "825265f7-7e30-4ac3-b9fb-16ba3869610e",
    "name": "Raouf Kamel",
    "requesterId": "451e4d6c-0380-41ed-95e6-275793c404c6",
    "imageUrl": null
}
```

in case of not found chat 
<img width="1227" height="609" alt="image" src="https://github.com/user-attachments/assets/70a5513a-44b7-4db2-947d-2ab847b24a4d" />
