### PR TITLE
Feature: TRN-56 update user categories

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
@@ -1,10 +1,7 @@
 package net.thechance.trends.api.controller
 
 import jakarta.validation.Valid
-import net.thechance.trends.api.dto.category.CategoryResponse
-import net.thechance.trends.api.dto.category.SubmitUserCategoriesRequest
-import net.thechance.trends.api.dto.category.SubmitUserCategoriesResponse
-import net.thechance.trends.api.dto.category.toCategoryResponse
+import net.thechance.trends.api.dto.category.*
 import net.thechance.trends.service.CategoryService
 import net.thechance.trends.service.TrendUserService
 import org.springframework.http.ResponseEntity
@@ -44,6 +41,32 @@ class CategoryController(
             allCategories.map { category ->
                 category.toCategoryResponse(isSelected = category in userCategories)
             }
+        )
+    }
+
+    @PatchMapping
+    fun patchUserCategories(
+        @RequestBody @Valid patchRequest: PatchUserCategoriesRequest,
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<PatchUserCategoriesResponse> {
+        val patchMetadata = trendUserService.patchUserCategories(
+            userId = userId,
+            categoriesToAdd = patchRequest.add,
+            categoriesToRemove = patchRequest.remove
+        )
+
+        val allCategories = categoryService.getAllCategories()
+        val userCategories = trendUserService.getUserSelectedCategories(userId)
+
+        val categoriesWithSelection = allCategories.map { category ->
+            category.toCategoryResponse(isSelected = category in userCategories)
+        }
+
+        return ResponseEntity.ok(
+            PatchUserCategoriesResponse(
+                patchMetadata = patchMetadata,
+                updatedCategories = categoriesWithSelection
+            )
         )
     }
 }

--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/CategoryController.kt
@@ -55,17 +55,14 @@ class CategoryController(
             categoriesToRemove = patchRequest.remove
         )
 
-        val allCategories = categoryService.getAllCategories()
-        val userCategories = trendUserService.getUserSelectedCategories(userId)
-
-        val categoriesWithSelection = allCategories.map { category ->
-            category.toCategoryResponse(isSelected = category in userCategories)
+        val userCategories = trendUserService.getUserSelectedCategories(userId).map { category ->
+            category.toCategoryResponse(isSelected = true)
         }
 
         return ResponseEntity.ok(
             PatchUserCategoriesResponse(
                 patchMetadata = patchMetadata,
-                updatedCategories = categoriesWithSelection
+                updatedCategories = userCategories
             )
         )
     }

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/PatchMetadata.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/PatchMetadata.kt
@@ -1,0 +1,6 @@
+package net.thechance.trends.api.dto
+
+data class PatchMetadata(
+    val addedCount: Int,
+    val removedCount: Int
+)

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesRequest.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesRequest.kt
@@ -1,0 +1,8 @@
+package net.thechance.trends.api.dto.category
+
+import java.util.*
+
+data class PatchUserCategoriesRequest(
+    val add: List<UUID> = emptyList(),
+    val remove: List<UUID> = emptyList()
+)

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesRequest.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesRequest.kt
@@ -1,8 +1,15 @@
 package net.thechance.trends.api.dto.category
 
+import jakarta.validation.constraints.AssertTrue
 import java.util.*
 
 data class PatchUserCategoriesRequest(
     val add: List<UUID> = emptyList(),
     val remove: List<UUID> = emptyList()
-)
+) {
+    @AssertTrue(message = "At least one operation (add or remove) is required")
+    fun isAtLeastOneOperationPresent() = add.isNotEmpty() || remove.isNotEmpty()
+
+    @AssertTrue(message = "Cannot add and remove the same category")
+    fun hasNoOverlap() = add.intersect(remove.toSet()).isEmpty()
+}

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesResponse.kt
@@ -1,7 +1,8 @@
 package net.thechance.trends.api.dto.category
 
+import net.thechance.trends.api.dto.PatchMetadata
+
 data class PatchUserCategoriesResponse(
-    val added: List<CategoryResponse>,
-    val removed: List<CategoryResponse>,
-    val current: List<CategoryResponse>
+    val patchMetadata: PatchMetadata,
+    val updatedCategories: List<CategoryResponse>
 )

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/category/PatchUserCategoriesResponse.kt
@@ -1,0 +1,7 @@
+package net.thechance.trends.api.dto.category
+
+data class PatchUserCategoriesResponse(
+    val added: List<CategoryResponse>,
+    val removed: List<CategoryResponse>,
+    val current: List<CategoryResponse>
+)

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -1,5 +1,6 @@
 package net.thechance.trends.service
 
+import net.thechance.trends.api.dto.PatchMetadata
 import net.thechance.trends.entity.Category
 import net.thechance.trends.entity.TrendUser
 import net.thechance.trends.exception.InvalidTrendInputException
@@ -39,7 +40,47 @@ class TrendUserService(
 
         val updatedUser = trendUser.copy(categories = categoryProxies)
         trendUserRepository.save(updatedUser)
+    }
 
+    fun patchUserCategories(
+        userId: UUID,
+        categoriesToAdd: List<UUID>,
+        categoriesToRemove: List<UUID>
+    ): PatchMetadata {
+        val allCategoryIds = (categoriesToAdd + categoriesToRemove).distinct()
+
+        if (allCategoryIds.isNotEmpty()) {
+            val existingCategoryCount = categoryRepository.countByIdIn(allCategoryIds.toMutableList())
+            if (existingCategoryCount != allCategoryIds.size.toLong()) {
+                throw TrendCategoryNotFoundException()
+            }
+        }
+
+        val trendUser = trendUserRepository.findById(userId).getOrElse { TrendUser(userId = userId) }
+
+        val currentCategories = trendUser.categories.toMutableSet()
+        val currentCategoryIds = currentCategories.map { it.id }.toSet()
+
+        var addedCount = 0
+        var removedCount = 0
+
+        categoriesToRemove.forEach { categoryId ->
+            currentCategories.removeIf { it.id == categoryId }.let { removed ->
+                if (removed) removedCount++
+            }
+        }
+
+        categoriesToAdd.forEach { categoryId ->
+            if (categoryId !in currentCategoryIds) {
+                currentCategories.add(categoryRepository.getReferenceById(categoryId))
+                addedCount++
+            }
+        }
+
+        val updatedUser = trendUser.copy(categories = currentCategories)
+        trendUserRepository.save(updatedUser)
+
+        return PatchMetadata(addedCount = addedCount, removedCount = removedCount)
     }
 
     fun getUserSelectedCategories(userId: UUID): Set<Category> {

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -5,6 +5,7 @@ import net.thechance.trends.entity.Category
 import net.thechance.trends.entity.TrendUser
 import net.thechance.trends.exception.InvalidTrendInputException
 import net.thechance.trends.exception.TrendCategoryNotFoundException
+import net.thechance.trends.exception.TrendUserNotFoundException
 import net.thechance.trends.repository.CategoryRepository
 import net.thechance.trends.repository.TrendUserRepository
 import org.springframework.stereotype.Service
@@ -20,20 +21,11 @@ class TrendUserService(
     private val categoryRepository: CategoryRepository
 ) {
     fun saveCategoriesToUser(userId: UUID, categoryIds: List<UUID>) {
+        if (categoryIds.isEmpty()) throw InvalidTrendInputException()
 
-        if (categoryIds.isEmpty()) {
-            throw InvalidTrendInputException()
-        }
+        validateCategoriesExist(categoryIds)
 
-        val existingCategoryCount = categoryRepository.countByIdIn(categoryIds.toMutableList())
-        if (existingCategoryCount != categoryIds.size.toLong()) {
-            throw TrendCategoryNotFoundException()
-        }
-
-        val trendUser = trendUserRepository.findById(userId).getOrElse {
-            TrendUser(userId = userId)
-        }
-
+        val trendUser = getOrCreateUser(userId)
         val categoryProxies = categoryIds.map { categoryId ->
             categoryRepository.getReferenceById(categoryId)
         }.toMutableSet()
@@ -48,39 +40,26 @@ class TrendUserService(
         categoriesToRemove: List<UUID>
     ): PatchMetadata {
         val allCategoryIds = (categoriesToAdd + categoriesToRemove).distinct()
+        validateCategoriesExist(allCategoryIds)
 
-        if (allCategoryIds.isNotEmpty()) {
-            val existingCategoryCount = categoryRepository.countByIdIn(allCategoryIds.toMutableList())
-            if (existingCategoryCount != allCategoryIds.size.toLong()) {
-                throw TrendCategoryNotFoundException()
-            }
+        val trendUser = getUserOrThrow(userId)
+        val currentCategoryIds = trendUser.categories.mapTo(mutableSetOf()) { it.id }
+
+        val actualRemoved = categoriesToRemove.filterTo(mutableSetOf()) { it in currentCategoryIds }
+        val actualAdded = categoriesToAdd.filterTo(mutableSetOf()) { it !in currentCategoryIds }
+
+        if (actualAdded.isEmpty() && actualRemoved.isEmpty()) {
+            return PatchMetadata(addedCount = 0, removedCount = 0)
         }
 
-        val trendUser = trendUserRepository.findById(userId).getOrElse { TrendUser(userId = userId) }
+        val updatedCategories = trendUser.categories
+            .filterNot { it.id in actualRemoved }
+            .plus(actualAdded.map { categoryRepository.getReferenceById(it) })
+            .toMutableSet()
 
-        val currentCategories = trendUser.categories.toMutableSet()
-        val currentCategoryIds = currentCategories.map { it.id }.toSet()
+        trendUserRepository.save(trendUser.copy(categories = updatedCategories))
 
-        var addedCount = 0
-        var removedCount = 0
-
-        categoriesToRemove.forEach { categoryId ->
-            currentCategories.removeIf { it.id == categoryId }.let { removed ->
-                if (removed) removedCount++
-            }
-        }
-
-        categoriesToAdd.forEach { categoryId ->
-            if (categoryId !in currentCategoryIds) {
-                currentCategories.add(categoryRepository.getReferenceById(categoryId))
-                addedCount++
-            }
-        }
-
-        val updatedUser = trendUser.copy(categories = currentCategories)
-        trendUserRepository.save(updatedUser)
-
-        return PatchMetadata(addedCount = addedCount, removedCount = removedCount)
+        return PatchMetadata(addedCount = actualAdded.size, removedCount = actualRemoved.size)
     }
 
     fun getUserSelectedCategories(userId: UUID): Set<Category> {
@@ -89,5 +68,17 @@ class TrendUserService(
 
     fun getDoesUserHaveCategories(userId: UUID): Boolean {
         return trendUserRepository.findById(userId).getOrNull()?.categories?.isNotEmpty() ?: false
+    }
+
+    private fun getUserOrThrow(userId: UUID) =
+        trendUserRepository.findById(userId).getOrNull() ?: throw TrendUserNotFoundException()
+
+    private fun getOrCreateUser(userId: UUID) =
+        trendUserRepository.findById(userId).getOrElse { TrendUser(userId = userId) }
+
+    private fun validateCategoriesExist(categoryIds: List<UUID>) {
+        if (categoryIds.isEmpty()) return
+        val existingCount = categoryRepository.countByIdIn(categoryIds.toMutableList())
+        if (existingCount != categoryIds.size.toLong()) throw TrendCategoryNotFoundException()
     }
 }

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -21,8 +21,7 @@ class TrendUserService(
     private val categoryRepository: CategoryRepository
 ) {
     fun saveCategoriesToUser(userId: UUID, categoryIds: List<UUID>) {
-        if (categoryIds.isEmpty()) throw InvalidTrendInputException()
-
+        validateCategoriesNotEmpty(categoryIds)
         validateCategoriesExist(categoryIds)
 
         val trendUser = getOrCreateUser(userId)
@@ -40,6 +39,8 @@ class TrendUserService(
         categoriesToRemove: List<UUID>
     ): PatchMetadata {
         val allCategoryIds = (categoriesToAdd + categoriesToRemove).distinct()
+
+        validateCategoriesNotEmpty(allCategoryIds)
         validateCategoriesExist(allCategoryIds)
 
         val trendUser = getUserOrThrow(userId)
@@ -76,8 +77,11 @@ class TrendUserService(
     private fun getOrCreateUser(userId: UUID) =
         trendUserRepository.findById(userId).getOrElse { TrendUser(userId = userId) }
 
+    private fun validateCategoriesNotEmpty(categoryIds: List<UUID>) {
+        if (categoryIds.isEmpty()) throw InvalidTrendInputException()
+    }
+
     private fun validateCategoriesExist(categoryIds: List<UUID>) {
-        if (categoryIds.isEmpty()) return
         val existingCount = categoryRepository.countByIdIn(categoryIds.toMutableList())
         if (existingCount != categoryIds.size.toLong()) throw TrendCategoryNotFoundException()
     }


### PR DESCRIPTION
## What is the PR Scope?

This PR introduces a new PATCH endpoint for managing user categories, allowing partial updates to a user's selected categories. The implementation includes:

- New PATCH endpoint at `/categories` for adding/removing categories
- Request validation to prevent overlapping add/remove operations
- Comprehensive response with patch metadata and updated category list
- Service layer logic to handle partial category updates
- Proper error handling for non-existent users and categories

## Why do we need that?

A PUT endpoint would require sending the entire category selection, which is inefficient for partial updates. This PATCH endpoint provides:

- **Efficiency**: Only send the categories to add/remove instead of full list
- **Better UX**: Clients can make incremental changes without tracking full state
- **Performance**: Reduced payload size and database operations
- **Atomic operations**: Multiple add/remove operations in single request

## Endpoints with Request and Response Body:

**Endpoint:** `PATCH /trends/categories`

**Request Headers:**
- Authentication: Bearer token required

**Request Body:**
```json
{
  "add": [
    "6f37ddc8-2c06-4a03-af79-c5079dd4d61f",
    "0d733503-5447-495b-a1be-41c222817d25"
  ],
  "remove": [
    "c8aac40e-74ff-4240-b6eb-6bbac7bcc27c",
    "1c0e34d9-737d-4003-a9dc-2c7ad14a9ca6",
    "e878f644-564c-45f7-ac95-e728567a7962"
  ]
}
```

**Response Body:**
```json
{
  "patchMetadata": {
    "addedCount": 2,
    "removedCount": 3
  },
  "updatedCategories": [
    {
      "id": "c8aac40e-74ff-4240-b6eb-6bbac7bcc27c",
      "name": "Technology",
      "emoji": "💻",
      "isSelected": false
    },
    // ... full list of categories with updated selection status
  ]
}
```