### PR TITLE
Feature/ TRN-71-add logic of reel likes and views

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
@@ -104,8 +104,12 @@ class ReelsController(
     fun toggleLike(
         @PathVariable reelId: UUID,
         @AuthenticationPrincipal currentUserId: UUID
-    ): ResponseEntity<Unit> {
+    ): ResponseEntity<ReelResponse> {
         reelsService.toggleLike(reelId = reelId, currentUserId)
-        return ResponseEntity.ok().build()
+        val reel = reelsService.getReelDetailsById(reelId)
+        val isLiked = reelsService.isReelLikedByUser(reel.id, currentUserId)
+
+        val reelResponse = reel.toResponse(isLiked).withOwnership(currentUserId = currentUserId, ownerId = reel.ownerId)
+        return ResponseEntity.ok(reelResponse)
     }
 }

--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/ReelsController.kt
@@ -17,14 +17,16 @@ class ReelsController(
     private val reelsService: ReelsService
 ) {
 
-    @GetMapping("/feed","/feed/{reelId}" )
+    @GetMapping("/feed", "/feed/{reelId}")
     fun getAllReelsForFeed(
         pageable: Pageable,
         @PathVariable(required = false) reelId: UUID? = null,
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<ReelResponse>> {
         val reels = reelsService.getAllReelsForFeed(pageable, currentUserId, reelId).content.map { reel ->
-            reel.toResponse().withOwnership(
+            val isLiked = reelsService.isReelLikedByUser(reel.id, currentUserId)
+
+            reel.toResponse(isLiked).withOwnership(
                 currentUserId = currentUserId,
                 ownerId = reel.ownerId,
             )
@@ -87,5 +89,23 @@ class ReelsController(
         )
 
         return ResponseEntity.ok(updatedReel.toResponse())
+    }
+
+    @PostMapping("/view/{reelId}")
+    fun recordView(
+        @PathVariable reelId: UUID,
+        @AuthenticationPrincipal currentUserId: UUID
+    ): ResponseEntity<Unit> {
+        reelsService.incrementViewCount(reelId, currentUserId)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/like/{reelId}")
+    fun toggleLike(
+        @PathVariable reelId: UUID,
+        @AuthenticationPrincipal currentUserId: UUID
+    ): ResponseEntity<Unit> {
+        reelsService.toggleLike(reelId = reelId, currentUserId)
+        return ResponseEntity.ok().build()
     }
 }

--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendUserController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendUserController.kt
@@ -8,13 +8,12 @@ import net.thechance.trends.api.dto.trendUser.DoesUserHaveCategoriesResponse
 import net.thechance.trends.service.ReelsService
 import net.thechance.trends.service.TrendUserService
 import org.springframework.data.domain.Pageable
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
 @RestController
 @RequestMapping("/${Constants.TRENDS_PATH}/user")
@@ -30,7 +29,9 @@ class TrendUserController(
     ): ResponseEntity<PagingResponse<ReelResponse>> {
 
         val reels = reelService.getAllReelsByUserId(pageable, currentUserId).content.map { reel ->
-            reel.toResponse().withOwnership(
+            val isLiked = reelService.isReelLikedByUser(reel.id, currentUserId)
+
+            reel.toResponse(isLiked).withOwnership(
                 currentUserId = currentUserId,
                 ownerId = reel.ownerId
             )

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/reel/ReelResponse.kt
@@ -1,6 +1,5 @@
 package net.thechance.trends.api.dto.reel
 
-import net.thechance.trends.entity.Category
 import net.thechance.trends.entity.Reel
 import java.time.LocalDateTime
 import java.util.*
@@ -13,12 +12,13 @@ data class ReelResponse(
     val createdAt: LocalDateTime,
     val likesCount: Int,
     val viewsCount: Int,
+    val isLiked: Boolean,
     val isCurrentUserOwner: Boolean,
     val username: String = "The Chance",
     val profilePictureUrl: String = "",
 )
 
-fun Reel.toResponse(): ReelResponse {
+fun Reel.toResponse(isLiked: Boolean = false): ReelResponse {
     return ReelResponse(
         reelId = id,
         thumbnailUrl = thumbnailUrl,
@@ -27,7 +27,8 @@ fun Reel.toResponse(): ReelResponse {
         createdAt = createdAt,
         likesCount = likesCount,
         viewsCount = viewsCount,
-        isCurrentUserOwner = false
+        isCurrentUserOwner = false,
+        isLiked = isLiked
     )
 }
 

--- a/trends/src/main/kotlin/net/thechance/trends/entity/ReelLike.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/entity/ReelLike.kt
@@ -1,0 +1,22 @@
+package net.thechance.trends.entity
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+import java.util.*
+
+@Table(name = "reel_likes", schema = "trends")
+@Entity
+data class ReelLike(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "reel_id", nullable = false)
+    val reelId: UUID,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "liked_at", nullable = false)
+    val likedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/trends/src/main/kotlin/net/thechance/trends/entity/ReelView.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/entity/ReelView.kt
@@ -1,0 +1,22 @@
+package net.thechance.trends.entity
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+import java.util.*
+
+@Table(name = "reel_views", schema = "trends")
+@Entity
+data class ReelView(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "reel_id", nullable = false)
+    val reelId: UUID,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "viewed_at", nullable = false)
+    val viewedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/trends/src/main/kotlin/net/thechance/trends/repository/ReelLikeRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/ReelLikeRepository.kt
@@ -1,0 +1,10 @@
+package net.thechance.trends.repository
+
+import net.thechance.trends.entity.ReelLike
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface ReelLikeRepository : JpaRepository<ReelLike, UUID> {
+    fun existsByReelIdAndUserId(reelId: UUID, userId: UUID): Boolean
+    fun deleteByReelIdAndUserId(reelId: UUID, userId: UUID)
+}

--- a/trends/src/main/kotlin/net/thechance/trends/repository/ReelViewRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/ReelViewRepository.kt
@@ -1,0 +1,9 @@
+package net.thechance.trends.repository
+
+import net.thechance.trends.entity.ReelView
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface ReelViewRepository : JpaRepository<ReelView, UUID> {
+    fun existsByReelIdAndUserId(reelId: UUID, userId: UUID): Boolean
+}

--- a/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
@@ -165,6 +165,14 @@ class ReelsService(
         return reelLikeRepository.existsByReelIdAndUserId(reelId, userId)
     }
 
+    fun getReelDetailsById(reelId: UUID): Reel{
+        val reel = reelsRepository.findById(reelId).orElseThrow {
+            ReelNotFoundException()
+        }
+
+        return reel
+    }
+
     companion object {
         private const val TRENDS_FOLDER_NAME = "trends"
     }

--- a/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
@@ -158,7 +158,7 @@ class ReelsService(
 
     private fun unlikeReel(reelId: UUID, userId: UUID, reel: Reel) {
         reelLikeRepository.deleteByReelIdAndUserId(reelId, userId)
-        reelsRepository.save(reel.copy(likesCount = maxOf(0,  - 1)))
+reelsRepository.save(reel.copy(likesCount = maxOf(0, reel.likesCount - 1)))
     }
 
     fun isReelLikedByUser(reelId: UUID, userId: UUID): Boolean {

--- a/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/ReelsService.kt
@@ -1,10 +1,14 @@
 package net.thechance.trends.service
 
 import net.thechance.trends.entity.Reel
+import net.thechance.trends.entity.ReelLike
+import net.thechance.trends.entity.ReelView
 import net.thechance.trends.exception.ReelNotFoundException
 import net.thechance.trends.exception.TrendCategoryNotFoundException
 import net.thechance.trends.exception.VideoDeleteFailedException
 import net.thechance.trends.repository.CategoryRepository
+import net.thechance.trends.repository.ReelLikeRepository
+import net.thechance.trends.repository.ReelViewRepository
 import net.thechance.trends.repository.ReelsRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -20,6 +24,8 @@ class ReelsService(
     private val reelsRepository: ReelsRepository,
     private val categoryRepository: CategoryRepository,
     private val fileStorageService: FileStorageService,
+    private val reelViewRepository: ReelViewRepository,
+    private val reelLikeRepository: ReelLikeRepository
 ) {
     fun getAllReelsByUserId(
         pageable: Pageable,
@@ -118,6 +124,45 @@ class ReelsService(
         val updatedReel = existingReel.copy(thumbnailUrl = thumbnailUrl)
 
         return reelsRepository.save(updatedReel)
+    }
+
+    @Transactional
+    fun incrementViewCount(reelId: UUID, userId: UUID) {
+        if (!reelViewRepository.existsByReelIdAndUserId(reelId, userId)) {
+            reelViewRepository.save(ReelView(reelId = reelId, userId = userId))
+
+            reelsRepository.findById(reelId).ifPresent { reel ->
+                reelsRepository.save(reel.copy(viewsCount = reel.viewsCount + 1))
+            }
+        }
+    }
+
+    @Transactional
+    fun toggleLike(reelId: UUID, currentUserId: UUID) {
+        val reel = reelsRepository.findById(reelId)
+            .orElseThrow { ReelNotFoundException() }
+
+        val isCurrentlyLiked = reelLikeRepository.existsByReelIdAndUserId(reelId, currentUserId)
+
+        if (isCurrentlyLiked) {
+            unlikeReel(reelId, currentUserId, reel)
+        } else {
+            likeReel(reelId, currentUserId, reel)
+        }
+    }
+
+    private fun likeReel(reelId: UUID, userId: UUID, reel: Reel) {
+        reelLikeRepository.save(ReelLike(reelId = reelId, userId = userId))
+        reelsRepository.save(reel.copy(likesCount = reel.likesCount + 1))
+    }
+
+    private fun unlikeReel(reelId: UUID, userId: UUID, reel: Reel) {
+        reelLikeRepository.deleteByReelIdAndUserId(reelId, userId)
+        reelsRepository.save(reel.copy(likesCount = maxOf(0,  - 1)))
+    }
+
+    fun isReelLikedByUser(reelId: UUID, userId: UUID): Boolean {
+        return reelLikeRepository.existsByReelIdAndUserId(reelId, userId)
     }
 
     companion object {


### PR DESCRIPTION
## what is the PR Scope ?
- Create new two repositories (`ReelLikeRepository`, `ReelViewRepository`)
- Create new Two entities (Tables) `ReelLike` and `ReelView`

## why do we need that ?
We need to track the likes and views of each user on each reel video

## end points with the request and response body:
For views -----> `POST    /trends/reels/view/{reelId}`
For likes-----> `POST    /trends/reels/like/{reelId}`

## Response body
```json
{
    "reelId": "e1008447-0b49-48c6-b6af-502957de4417",
    "thumbnailUrl": "http://localhost.localstack.cloud:4566/thumbnail/trends/_640x_3455d99ca18d07ea29414a9d1add8a92e1794ac317fbbf6196ddf0f4846a9e63.jpg_2025-10-16T13:50:01.908753500.jpg",
    "videoUrl": "http://localhost.localstack.cloud:4566/mena-trends/video/trends/file_example_MP4_1920_18MG.mp4_2025-10-16T13:41:49.207992900.mp4",
    "description": "",
    "createdAt": "2025-10-16T13:41:49.682861",
    "likesCount": 1,
    "viewsCount": 3,
    "isLiked": true,
    "isCurrentUserOwner": false,
    "username": "The Chance",
    "profilePictureUrl": ""
}