### PR TITLE
refactor/CHT-74-let-backend-allow-subsecribtion-to-all-private-messages-at-once

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/api/config/WebSocketConfig.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/config/WebSocketConfig.kt
@@ -11,10 +11,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 class WebSocketConfig : WebSocketMessageBrokerConfigurer {
 
     override fun configureMessageBroker(config: MessageBrokerRegistry) {
-        config.enableSimpleBroker("/user")
+        config.enableSimpleBroker("/private")
         config.setApplicationDestinationPrefixes("/app")
         config.setUserDestinationPrefix("/user")
-
     }
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
@@ -23,15 +23,22 @@ class ChatController(
 ) {
 
     @MessageMapping("/chat.privateMessage")
-    fun sendPrivateMessage(@Payload chatMessage: MessageRequestDto, principal: Principal) {
+    fun sendPrivateMessage(
+        @Payload chatMessage: MessageRequestDto,
+        principal: Principal
+    ) {
         val senderId = UUID.fromString(principal.name)
-        val createdMessage = chatMessage.toCreateMessageArgs(senderId = senderId)
-        chatService.saveMessage(createdMessage)
-        sendToChatParticipants(
-            chatId = chatMessage.chatId,
-            destination = PRIVATE_MESSAGES,
-            message = createdMessage
-        )
+        val message = chatService.saveMessage(chatMessage.toCreateMessageArgs(senderId = senderId))
+
+        chatService
+            .getChatUsersIds(chatId = chatMessage.chatId)
+            .forEach { chatParticipantId ->
+                messagingTemplate.convertAndSendToUser(
+                    chatParticipantId.toString(),
+                    PRIVATE_MESSAGES,
+                    message.toResponse(chatParticipantId)
+                )
+            }
     }
 
     @GetMapping
@@ -49,10 +56,11 @@ class ChatController(
     @GetMapping("/history")
     fun getChatHistory(
         @RequestParam chatId: UUID,
+        @AuthenticationPrincipal userId: UUID,
         pageable: Pageable
-    ): ResponseEntity<PagedResponse<MessageDto>> {
+    ): ResponseEntity<PagedResponse<MessageResponse>> {
         return ResponseEntity.ok(
-            chatService.getAllChatMessages(chatId, pageable).toPagedMessageResponse()
+            chatService.getAllChatMessages(chatId, pageable).toPagedMessageResponse(userId)
         )
     }
 
@@ -63,31 +71,34 @@ class ChatController(
     ) {
         val userId = UUID.fromString(principal.name)
         chatService.markChatMessagesAsRead(markAsReadRequest.chatId, userId)
-        sendToChatParticipants(
-            chatId = markAsReadRequest.chatId,
-            destination = PRIVATE_MESSAGES,
-            message = MarkAsReadResponse(userId)
-        )
+
+        chatService
+            .getChatUsersIds(chatId = markAsReadRequest.chatId)
+            .forEach { chatParticipantId ->
+                messagingTemplate.convertAndSendToUser(
+                    chatParticipantId.toString(),
+                    PRIVATE_MESSAGES,
+                    MarkAsReadResponse(userId, markAsReadRequest.chatId, chatParticipantId == userId)
+                )
+            }
     }
 
     @GetMapping("/chatsSummary")
-    fun getUserChatList(
+    fun getUserChatSummary(
         @AuthenticationPrincipal userId: UUID,
         pageable: Pageable
     ): ResponseEntity<PagedResponse<ChatSummaryResponse>> {
-        val chats = chatService.getUserChats(userId, pageable)
+        val chats = chatService.getUserChatsSummaries(userId, pageable)
         return ResponseEntity.ok(chats.toPagedResponse())
     }
 
-    private fun sendToChatParticipants(chatId: UUID, destination: String, message: Any) {
-        val chatUsersIds = chatService.getChatUsersIds(chatId = chatId)
-        chatUsersIds.forEach { chatParticipantId ->
-            messagingTemplate.convertAndSendToUser(
-                chatParticipantId.toString(),
-                destination,
-                message
-            )
-        }
+    @GetMapping("/chatsSummary/{chatId}")
+    fun getUserChatSummaryById(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable chatId: UUID,
+    ): ResponseEntity<ChatSummaryResponse> {
+        val chat = chatService.getUserChatSummaryById(chatId, userId)
+        return ResponseEntity.ok(chat.toResponse())
     }
 
     @GetMapping("/{chatId}")

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/ChatController.kt
@@ -27,8 +27,9 @@ class ChatController(
         val senderId = UUID.fromString(principal.name)
         val createdMessage = chatMessage.toCreateMessageArgs(senderId = senderId)
         chatService.saveMessage(createdMessage)
-        sendMessageToUser(
-            user = chatMessage.chatId.toString(),
+        sendToChatParticipants(
+            chatId = chatMessage.chatId,
+            destination = PRIVATE_MESSAGES,
             message = createdMessage
         )
     }
@@ -51,7 +52,7 @@ class ChatController(
         pageable: Pageable
     ): ResponseEntity<PagedResponse<MessageDto>> {
         return ResponseEntity.ok(
-            chatService.getAllChatMessages(chatId,pageable).toPagedMessageResponse()
+            chatService.getAllChatMessages(chatId, pageable).toPagedMessageResponse()
         )
     }
 
@@ -61,11 +62,12 @@ class ChatController(
         principal: Principal
     ) {
         val userId = UUID.fromString(principal.name)
-        sendMessageToUser(
-            user = markAsReadRequest.chatId.toString(),
+        chatService.markChatMessagesAsRead(markAsReadRequest.chatId, userId)
+        sendToChatParticipants(
+            chatId = markAsReadRequest.chatId,
+            destination = PRIVATE_MESSAGES,
             message = MarkAsReadResponse(userId)
         )
-        chatService.markChatMessagesAsRead(markAsReadRequest.chatId, userId)
     }
 
     @GetMapping("/chatsSummary")
@@ -77,24 +79,27 @@ class ChatController(
         return ResponseEntity.ok(chats.toPagedResponse())
     }
 
-    private fun sendMessageToUser(user: String, message: Any) {
-        messagingTemplate.convertAndSendToUser(
-            user,
-            QUEUE_MESSAGES,
-            message
-        )
+    private fun sendToChatParticipants(chatId: UUID, destination: String, message: Any) {
+        val chatUsersIds = chatService.getChatUsersIds(chatId = chatId)
+        chatUsersIds.forEach { chatParticipantId ->
+            messagingTemplate.convertAndSendToUser(
+                chatParticipantId.toString(),
+                destination,
+                message
+            )
+        }
     }
 
     @GetMapping("/{chatId}")
     fun getChatDetail(
-        @PathVariable chatId : UUID,
+        @PathVariable chatId: UUID,
         @AuthenticationPrincipal userId: UUID
-    ): ResponseEntity<ChatResponse>{
-       val chat = chatService.getChatById(chatId, userId)
+    ): ResponseEntity<ChatResponse> {
+        val chat = chatService.getChatById(chatId, userId)
         return ResponseEntity.ok(chat.toResponse())
     }
 
     companion object {
-        const val QUEUE_MESSAGES = "/queue/messages"
+        const val PRIVATE_MESSAGES = "/private/messages"
     }
 }

--- a/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/controller/UserController.kt
@@ -1,7 +1,7 @@
 package net.thechance.chat.api.controller
 
 import net.thechance.chat.api.dto.UserDto
-import net.thechance.chat.api.dto.toDto
+import net.thechance.chat.api.dto.toResponse
 import net.thechance.chat.service.ContactUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -20,6 +20,6 @@ class UserController (
     fun getUserById(
         @AuthenticationPrincipal userId : UUID
     ):  ResponseEntity<UserDto>{
-        return ResponseEntity.ok(contactUserService.getUserById(userId).toDto())
+        return ResponseEntity.ok(contactUserService.getUserById(userId).toResponse())
     }
 }

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MarkAsReadRequest.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MarkAsReadRequest.kt
@@ -6,6 +6,3 @@ data class MarkAsReadRequest(
     val chatId: UUID
 )
 
-data class MarkAsReadResponse(
-    val readBy: UUID
-)

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MarkAsReadResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MarkAsReadResponse.kt
@@ -1,0 +1,9 @@
+package net.thechance.chat.api.dto
+
+import java.util.UUID
+
+data class MarkAsReadResponse(
+    val readByUserId: UUID,
+    val chatId: UUID,
+    val readByMe: Boolean
+)

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageResponse.kt
@@ -11,41 +11,40 @@ data class MessageRequestDto(
     val text: String,
 )
 
-data class MessageDto(
+data class MessageResponse(
     val id: UUID,
     val senderId: UUID,
     val chatId: UUID,
     val text: String,
     val sendAt: Instant,
-    val isRead: Boolean
+    val isRead: Boolean,
+    val isMine: Boolean
 )
 
 
-fun Message.toDto(): MessageDto {
-    return MessageDto(
+fun Message.toResponse(requesterId: UUID): MessageResponse {
+    return MessageResponse(
         id = this.id,
         senderId = this.senderId,
         chatId = this.chat.id,
         text = this.text,
         sendAt = this.sentAt,
-        isRead = this.isRead
+        isRead = this.isRead,
+        isMine = requesterId == senderId
     )
 }
 
 fun MessageRequestDto.toCreateMessageArgs(senderId: UUID): CreateMessageArgs {
     return CreateMessageArgs(
-        id = UUID.randomUUID(),
         senderId = senderId,
         chatId = this.chatId,
         text = this.text,
-        sendAt = Instant.now(),
-        isRead = false
     )
 }
 
-fun Page<Message>.toPagedMessageResponse(): PagedResponse<MessageDto> {
+fun Page<Message>.toPagedMessageResponse(requesterId: UUID): PagedResponse<MessageResponse> {
     return PagedResponse(
-        data = this.content.map { it.toDto() },
+        data = this.content.map { it.toResponse(requesterId) },
         pageNumber = this.number,
         pageSize = this.size,
         totalItems = this.totalElements,

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/UserDto.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/UserDto.kt
@@ -9,7 +9,7 @@ data class UserDto(
     val imageUrl: String? = null,
 )
 
-fun ContactUser.toDto(): UserDto{
+fun ContactUser.toResponse(): UserDto{
     return UserDto(
         firstName = this.firstName,
         lastName = this.lastName,

--- a/chat/src/main/kotlin/net/thechance/chat/repository/ChatRepository.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/repository/ChatRepository.kt
@@ -43,5 +43,21 @@ interface ChatRepository : JpaRepository<Chat, UUID> {
     fun findUnreadCountsForChats(
         @Param("chatIds") chatIds: List<UUID>
     ): List<ChatUnreadMessagesCount>
+
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT
+            m.chat_id AS chatId,
+            COUNT(*) AS unreadCount
+        FROM chat.messages m
+        WHERE m.is_read = FALSE
+          AND m.chat_id = :chatId
+        GROUP BY m.chat_id
+    """
+    )
+    fun findUnreadCountForChat(
+        @Param("chatId") chatId: UUID
+    ): ChatUnreadMessagesCount
 }
 

--- a/chat/src/main/kotlin/net/thechance/chat/repository/ChatRepository.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/repository/ChatRepository.kt
@@ -43,21 +43,5 @@ interface ChatRepository : JpaRepository<Chat, UUID> {
     fun findUnreadCountsForChats(
         @Param("chatIds") chatIds: List<UUID>
     ): List<ChatUnreadMessagesCount>
-
-    @Query(
-        nativeQuery = true,
-        value = """
-        SELECT
-            m.chat_id AS chatId,
-            COUNT(*) AS unreadCount
-        FROM chat.messages m
-        WHERE m.is_read = FALSE
-          AND m.chat_id = :chatId
-        GROUP BY m.chat_id
-    """
-    )
-    fun findUnreadCountForChat(
-        @Param("chatId") chatId: UUID
-    ): ChatUnreadMessagesCount
 }
 

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -66,7 +66,7 @@ class ChatService(
         val lastMessages = messageRepository.findLastMessagesForChats(chatIds)
         val unreadCounts = chatRepository.findUnreadCountsForChats(chatIds)
 
-        val chatSummaries = chats.map { chat ->
+        val chatsSummaries = chats.map { chat ->
             val otherUser = chat.users.firstOrNull { it.id != userId }
             chat.toSummary(
                 userId,
@@ -75,14 +75,14 @@ class ChatService(
                 unreadCounts.firstOrNull { it.chatId == chat.id }?.unreadCount ?: 0
             )
         }
-        return chatSummaries
+        return chatsSummaries
     }
 
     fun getUserChatSummaryById(chatId: UUID, userId: UUID): ChatSummary {
         val chat = chatRepository.findByIdOrNull(chatId) ?: throw NotFoundException("no chat was found with id: $chatId")
         val otherUser = chat.users.firstOrNull { it.id != userId }
         val lastMessage = messageRepository.findTopByChatIdOrderBySentAtDesc(chatId)
-        val unreadCount = chatRepository.findUnreadCountForChat(chatId).unreadCount
+        val unreadCount = chatRepository.findUnreadCountsForChats(listOf(chatId)).firstOrNull()?.unreadCount ?: 0
         return chat.toSummary(
             userId,
             otherUser,

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -39,17 +39,17 @@ class ChatService(
         return chatRepository.save(Chat(users = mutableSetOf(requester, otherUser)))
     }
 
-    fun saveMessage(message: CreateMessageArgs) {
+    fun saveMessage(message: CreateMessageArgs): Message {
         val chat = entityManager.getReference(Chat::class.java, message.chatId)
-        messageRepository.save(
-            Message(
-                id = message.id,
-                senderId = message.senderId,
-                chat = chat,
-                text = message.text,
-                sentAt = message.sendAt,
-            )
+        val message = Message(
+            senderId = message.senderId,
+            chat = chat,
+            text = message.text,
         )
+        messageRepository.save(
+            message
+        )
+        return message
     }
 
     fun getAllChatMessages(chatId: UUID, pageable: Pageable) =
@@ -59,7 +59,7 @@ class ChatService(
     fun markChatMessagesAsRead(chatId: UUID, userId: UUID) =
         messageRepository.updateIsReadByChatIdAndSenderIdNot(chatId = chatId, userId = userId)
 
-    fun getUserChats(userId: UUID, pageable: Pageable): Page<ChatSummary> {
+    fun getUserChatsSummaries(userId: UUID, pageable: Pageable): Page<ChatSummary> {
         val chats = chatRepository.findAllByUserId(userId, pageable)
         val chatIds = chats.content.map { it.id }
 
@@ -76,6 +76,19 @@ class ChatService(
             )
         }
         return chatSummaries
+    }
+
+    fun getUserChatSummaryById(chatId: UUID, userId: UUID): ChatSummary {
+        val chat = chatRepository.findByIdOrNull(chatId) ?: throw NotFoundException("no chat was found with id: $chatId")
+        val otherUser = chat.users.firstOrNull { it.id != userId }
+        val lastMessage = messageRepository.findTopByChatIdOrderBySentAtDesc(chatId)
+        val unreadCount = chatRepository.findUnreadCountForChat(chatId).unreadCount
+        return chat.toSummary(
+            userId,
+            otherUser,
+            lastMessage,
+            unreadCount
+        )
     }
 
     fun getChatById(chatId: UUID, userId: UUID): ChatModel {

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -92,6 +92,11 @@ class ChatService(
         )
     }
 
+    fun getChatUsersIds(chatId: UUID): List<UUID> {
+        val chat = chatRepository.findByIdOrNull(chatId) ?: throw NotFoundException("no chat was found with id: $chatId")
+        return chat.users.map { it.id }
+    }
+
     private fun getChatName(contact: Contact?, user: ContactUser? ): String{
         return contact?.let { "${it.firstName} ${it.lastName}" }
             ?: user?.let { "${it.firstName} ${it.lastName}" }.orEmpty()

--- a/chat/src/main/kotlin/net/thechance/chat/service/args/CreateMessageArgs.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/args/CreateMessageArgs.kt
@@ -4,10 +4,7 @@ import java.time.Instant
 import java.util.*
 
 data class CreateMessageArgs(
-    val id: UUID,
     val senderId: UUID,
     val chatId: UUID,
     val text: String,
-    val sendAt: Instant,
-    val isRead: Boolean
 )

--- a/chat/src/main/kotlin/net/thechance/chat/service/args/CreateMessageArgs.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/args/CreateMessageArgs.kt
@@ -1,6 +1,5 @@
 package net.thechance.chat.service.args
 
-import java.time.Instant
 import java.util.*
 
 data class CreateMessageArgs(

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
@@ -113,7 +113,7 @@ class ChatControllerTest {
 
         every { chatService.getAllChatMessages(chatId, pageable) } returns page
 
-        val response = controller.getChatHistory(chatId, pageable)
+        val response = controller.getChatHistory(chatId, UUID.randomUUID(), pageable)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data).hasSize(1)
@@ -137,7 +137,7 @@ class ChatControllerTest {
             messagingTemplate.convertAndSendToUser(
                 chatId.toString(),
                 PRIVATE_MESSAGES,
-                MarkAsReadResponse(userId, chatId)
+                MarkAsReadResponse(userId, chatId, true)
             )
         }
         verify { chatService.markChatMessagesAsRead(chatId, userId) }

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import net.thechance.chat.api.controller.ChatController.Companion.QUEUE_MESSAGES
+import net.thechance.chat.api.controller.ChatController.Companion.PRIVATE_MESSAGES
 import net.thechance.chat.api.dto.ChatResponse
 import net.thechance.chat.api.dto.MarkAsReadRequest
 import net.thechance.chat.api.dto.MarkAsReadResponse
@@ -136,7 +136,7 @@ class ChatControllerTest {
         verify {
             messagingTemplate.convertAndSendToUser(
                 chatId.toString(),
-                QUEUE_MESSAGES,
+                PRIVATE_MESSAGES,
                 MarkAsReadResponse(userId)
             )
         }

--- a/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/api/controller/ChatControllerTest.kt
@@ -137,7 +137,7 @@ class ChatControllerTest {
             messagingTemplate.convertAndSendToUser(
                 chatId.toString(),
                 PRIVATE_MESSAGES,
-                MarkAsReadResponse(userId)
+                MarkAsReadResponse(userId, chatId)
             )
         }
         verify { chatService.markChatMessagesAsRead(chatId, userId) }

--- a/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
@@ -113,12 +113,9 @@ class ChatServiceTest {
     fun `saveMessage saves message when chat exists`() {
         val chat = testChat()
         val messageDto = CreateMessageArgs(
-            id = UUID.randomUUID(),
             chatId = chat.id,
             senderId = UUID.randomUUID(),
             text = "message 1",
-            sendAt = Instant.now(),
-            isRead = false
         )
 
         every { entityManager.getReference(Chat::class.java, chat.id) } returns chat
@@ -139,12 +136,9 @@ class ChatServiceTest {
     @Test
     fun `saveMessage throws exception when chat not found`() {
         val messageDto = CreateMessageArgs(
-            id = UUID.randomUUID(),
             chatId = UUID.randomUUID(),
             senderId = UUID.randomUUID(),
             text = "message 1",
-            sendAt = Instant.now(),
-            isRead = false
         )
 
         every { entityManager.getReference(Chat::class.java, messageDto.chatId) } throws EntityNotFoundException()
@@ -205,9 +199,8 @@ class ChatServiceTest {
     }
 
     private companion object {
-        val chatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-16ba3869610e")
-        val userId = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6")
-        val notAvailableChatId = UUID.fromString("825265f7-7e30-4ac3-b9fb-87ba3869610e")
+        val chatId: UUID = UUID.fromString("825265f7-7e30-4ac3-b9fb-16ba3869610e")
+        val userId: UUID = UUID.fromString("451e4d6c-0380-41ed-95e6-275793c404c6")
 
         val contact = Contact(
             id = UUID.fromString("73439a0a-adfa-4bf7-86ad-0d66435d5f18"),

--- a/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
+++ b/chat/src/test/kotlin/net/thechance/chat/service/ChatServiceTest.kt
@@ -311,7 +311,7 @@ class ChatServiceTest {
         )
         every { contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id) } returns contact
 
-        val result = service.getUserChats(userId, pageable)
+        val result = service.getUserChatsSummaries(userId, pageable)
         val firstChat = result.content.first()
 
         assertThat(firstChat.lastMessage?.isMine).isTrue()
@@ -327,7 +327,7 @@ class ChatServiceTest {
         every { messageRepository.findLastMessagesForChats(emptyList()) } returns emptyList()
         every { chatRepository.findUnreadCountsForChats(emptyList()) } returns emptyList()
 
-        val result = service.getUserChats(userId, pageable)
+        val result = service.getUserChatsSummaries(userId, pageable)
 
         assertThat(result.content).isEmpty()
         assertThat(result.totalElements).isEqualTo(0)


### PR DESCRIPTION
## what is the PR Scope ?
allow the client to subsection to all his private messages from all his chats at once, and add a new end point to return a chat summary by id.

there ware also some fixes and refactors. for example:
- putting extra necessary parameter in the MarkMassageAsReadEvent, like which message? and in which chat?
- removing some code to preserve the api/service/repo responsibility structure
- ...

## why do we need that ?

this is necessary to update the main chat screen in the mobile app, where it should listen to all the messages from all the user chats, and update the up based on new messages.
so no need for a new ws session each time the client need to get the messages of another chat.

## end points with the request and response body:
end point: `/chat/chatsSummary/{chatId}`
response:
```
{
    "id": "ec5ffb28-308b-4f92-ae62-e3bfc319dc27",
    "name": "Nabil Bouzine",
    "imageUrl": "https://cdn.marketplaceevents.com/sitefinity/images/default-source/icons/sunflower.png",
    "lastMessage": {
        "text": "hello",
        "sentAt": "2025-10-16T14:20:58.141784Z",
        "isMine": true
    },
    "unReadMessagesCount": 1
}
```