### PR TITLE
update Hibernate DDL configuration to `update` in application properties

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.password=${DATABASE_PASSWORD}
 
 jwt.secret-key=${JWT_SECRET}
 
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 
 # Available profiles: dev, stg, prod
 spring.profiles.active=${ACTIVE_PROFILE}


### PR DESCRIPTION
## what is the PR Scope ?

- set hibernate auto ddl to "update"

## why do we need that ?

- so we can update the database on the server