### PR TITLE
refactor/DKN-95-fixe-get-dukan-stause-end-point

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 interface DukanRepository : JpaRepository<Dukan, UUID> {
     fun existsByName(name: String): Boolean
     fun existsByOwnerId(ownerId: UUID): Boolean
-    fun findByOwnerId(ownerId: UUID): Dukan
+    fun findByOwnerId(ownerId: UUID): Dukan?
     @Query(
         """
     SELECT DISTINCT d


### PR DESCRIPTION
## what is the PR Scope ?
dukan feature getting the current user dukan status 

## why do we need that ?
right now because we didn't explicitly specifies the type nullable the jpa throw other exception internally not the DukanNotFoundException

## end points with the request and response body:
request :
https://mena-dev.the-chance.net/dukan/statues
response:
{
  "message": "Dukan not found",
  "errors": null,
  "errorCode": 1102
}
