### PR TITLE
Feature: IDN-119 implement get active address.

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/AddressController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/AddressController.kt
@@ -52,6 +52,14 @@ class AddressController(
         return ResponseEntity.ok(getAllAddressesResponse)
     }
 
+    @GetMapping("/active")
+    fun getActiveAddress(
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<AddressResponse> {
+        val activeAddressResponse = addressService.getActiveAddress(userId).toResponse()
+        return ResponseEntity.ok(activeAddressResponse)
+    }
+
     @DeleteMapping("/{id}")
     fun deleteAddress(
         @AuthenticationPrincipal userId: UUID,

--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/AddressControllerAdvice.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/AddressControllerAdvice.kt
@@ -84,4 +84,12 @@ class AddressControllerAdvice {
             .status(HttpStatus.FORBIDDEN)
             .body(ErrorResponse(exception.message ?: "Address Can Not Be Updated"))
     }
+
+    @ExceptionHandler(NoActiveAddressException::class)
+    fun handleNoActiveAddressException(exception: NoActiveAddressException): ResponseEntity<ErrorResponse?> {
+        logger.error(exception.message)
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(exception.message ?: "No active address"))
+    }
 }

--- a/identity/src/main/kotlin/net/thechance/identity/exception/AddressException.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/exception/AddressException.kt
@@ -8,3 +8,4 @@ class AddressNotUpdatedException(message: String = "Address Not Updated"): Addre
 class AddressNotDeletedException(message: String = "Address Not Deleted"): AddressException(message)
 class AtLeastAddressValueNeededException(message: String = "At least one value needed to update"): AddressException(message)
 class AddressCanNotBeUpdatedException(message: String = "Address Can Not Be Updated"): AddressException(message)
+class NoActiveAddressException(message: String = "No active address"): AddressException(message)

--- a/identity/src/main/kotlin/net/thechance/identity/service/AddressService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/AddressService.kt
@@ -67,6 +67,10 @@ class AddressService(
         return addressRepository.findByIdAndUserId(addressId, userId) ?: throw AddressNotFoundException()
     }
 
+    fun getActiveAddress(userId: UUID): Address {
+        return addressRepository.findByIsActiveAndUserId(true, userId) ?: throw NoActiveAddressException()
+    }
+
     private fun createAddress(user: User, addressToAdd: CreateAddressRequest, isActive: Boolean = false): Address {
         return Address(
             user = user,


### PR DESCRIPTION
## what is the PR Scope ?
- Add end point for getting active address for specific user

## why do we need that ?
- Other features needs that to access the active address from the domain of identity.

## end points with the request and response body:
- Get Active Address:  `/identity/addresses/active`
Crul: 
``` 
curl --location 'https://mena-dev.the-chance.net/identity/addresses/active' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyN2EyMDg0Yi05MTY0LTQxZWUtYjM4NS1jMjM1NzlkZjcwOWIiLCJpYXQiOjE3NjEzMTgxMDIsImV4cCI6MTc2MTMyMTcwMn0.Mg-eOThZP5-k8xbj-y0gWSP5rGoaLMUh1IVwrMNPbR0' \
--data ''
```
Request: No Body

Response:
```json
{
    "id": "83823eb8-373b-4ebb-a5da-73062d2ccff2",
    "latitude": -30.123,
    "longitude": -30.0,
    "addressLine": "Cairo,Egypt",
    "addressType": "Home",
    "isActive": true
}
```