### PR TITLE
fix: fix delete when uploading and add details endpoint for my trends screen

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendUserController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendUserController.kt
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
@@ -18,13 +19,14 @@ class TrendUserController(
     private val trendsService: TrendsService
 ) {
 
-    @GetMapping
+    @GetMapping("/{trendId}", "")
     fun getAllTrendsByUserId(
         pageable: Pageable,
+        @PathVariable(required = false) trendId: UUID? = null,
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<TrendResponse>> {
 
-        val trends = trendsService.getAllTrendsByUserId(pageable, currentUserId).content.map { it.toResponse() }
+        val trends = trendsService.getAllTrendsByUserId(pageable, currentUserId, trendId).content.map { it.toResponse() }
 
         val result = PagingResponse(
             pageNumber = pageable.pageNumber,

--- a/trends/src/main/kotlin/net/thechance/trends/models/TrendUrls.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/models/TrendUrls.kt
@@ -2,5 +2,5 @@ package net.thechance.trends.models
 
 interface TrendUrls {
     fun getTrendVideoUrl(): String
-    fun getTrendThumbnailUrl(): String
+    fun getTrendThumbnailUrl(): String?
 }

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
@@ -22,15 +22,21 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
         LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :ownerId
         WHERE t.ownerId = :ownerId 
         AND t.isPublished = :isPublished
+        AND (:trendId IS NULL OR t.createdAt <= (
+            SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+        ))
         """,
         countQuery = """
         SELECT COUNT(t.id)
         FROM Trend t
         WHERE t.ownerId = :ownerId 
         AND t.isPublished = :isPublished
+        AND (:trendId IS NULL OR t.createdAt <= (
+            SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+        ))
         """
     )
-    fun findByOwnerIdAndIsPublished(ownerId: UUID, isPublished: Boolean, pageable: Pageable): Page<TrendWithLikeStatus>
+    fun findByOwnerIdAndIsPublished(ownerId: UUID, isPublished: Boolean, trendId: UUID?, pageable: Pageable): Page<TrendWithLikeStatus>
 
     @Query(
         """

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
@@ -31,17 +31,19 @@ class TrendsService(
 ) {
     fun getAllTrendsByUserId(
         pageable: Pageable,
-        currentUserId: UUID
+        currentUserId: UUID,
+        trendId: UUID?
     ): Page<TrendWithOwnerShipAndLikeStatus> {
 
         val body = trendsRepository.findByOwnerIdAndIsPublished(
             currentUserId,
             true,
+            trendId,
             PageRequest.of(
                 pageable.pageNumber,
                 10,
                 pageable.getSortOr(Sort.by(Sort.Direction.DESC, "createdAt"))
-            ),
+            )
         ).map { it.withOwnership(currentUserId = currentUserId) }
         return body
     }
@@ -69,7 +71,7 @@ class TrendsService(
 
         trendsRepository.deleteTrendById(id)
         fileStorageService.deleteFile(trendUrls.getTrendVideoUrl())
-        fileStorageService.deleteFile(trendUrls.getTrendThumbnailUrl())
+        trendUrls.getTrendThumbnailUrl()?.let { fileStorageService.deleteFile(it) }
     }
 
     @Transactional


### PR DESCRIPTION
## what is the PR Scope ?
fix behavior in deleting a trend in the upload screen before it has a thunbnail would fail so i added a null check before it attempts to delete a trend without a thumbnail (which is valid). also added an extra optional parameter for the get my trends endpoint so that the mobile can use it

## why do we need that ?
to fix incorrect behavior when calling these endpoints

## end points with the request and response body:
`trends/user/trendId` same response just narrower results