### PR TITLE
fix image url extra backslash

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/ProfileController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/ProfileController.kt
@@ -46,7 +46,7 @@ class ProfileController(
         @RequestPart("file") file: MultipartFile,
     ): ResponseEntity<UpdateImageResponse> {
         val imageUri = userService.updateUserImage(userId, file)
-        val response = UpdateImageResponse(imageUrl= "$imagesBaseUrl/$imageUri")
+        val response = UpdateImageResponse(imageUrl = "$imagesBaseUrl$imageUri")
         return ResponseEntity.ok(response)
     }
 

--- a/identity/src/main/kotlin/net/thechance/identity/service/IdentityImageStorageService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/IdentityImageStorageService.kt
@@ -30,7 +30,7 @@ class IdentityImageStorageService(
         try {
             val fileName = "${fileName}.$extension"
             val randomParameter = LocalDateTime.now().toString()
-            val key = "$folderName/$fileName"
+            val key = "$folderName$fileName"
             val putReq = createObjectRequest(key, mimeType)
             menaS3Client.putObject(putReq, RequestBody.fromBytes(file.bytes))
             val imageUri = "$fileName?time=$randomParameter"


### PR DESCRIPTION
## What is the PR Scope?
Upload and get the user profile image

## Why do we need that?
There is an extra backslash when saving the image URL: `"https://menastorage.fra1.cdn.digitaloceanspaces.com//identity/profile/image/image.jpg"`
