### PR TITLE
feat: add logout endpoint for admin authentication

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/AdminAuthController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/AdminAuthController.kt
@@ -6,10 +6,12 @@ import net.thechance.identity.api.dto.AuthResponse
 import net.thechance.identity.api.dto.RefreshTokenRequest
 import net.thechance.identity.service.AdminAuthenticationService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping("/identity/admin/authentication")
@@ -28,5 +30,12 @@ class AdminAuthController(
         val response = adminAuthenticationService.refreshToken(request.refreshToken)
         return ResponseEntity.ok(response)
     }
-}
 
+    @PostMapping("/logout")
+    fun logout(
+        @AuthenticationPrincipal adminId: UUID
+    ): ResponseEntity<Unit> {
+        adminAuthenticationService.logout(adminId)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/identity/src/main/kotlin/net/thechance/identity/repository/AdminRefreshTokenRepository.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/repository/AdminRefreshTokenRepository.kt
@@ -2,7 +2,9 @@ package net.thechance.identity.repository
 
 import net.thechance.identity.entity.AdminRefreshToken
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
 interface AdminRefreshTokenRepository : JpaRepository<AdminRefreshToken, Long> {
     fun findByRefreshToken(refreshToken: String): AdminRefreshToken?
+    fun removeByAdminUserId(adminUserId: UUID)
 }

--- a/identity/src/main/kotlin/net/thechance/identity/service/AdminAuthenticationService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/AdminAuthenticationService.kt
@@ -9,6 +9,8 @@ import net.thechance.identity.repository.AdminUserRepository
 import net.thechance.identity.security.JwtService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 class AdminAuthenticationService(
@@ -35,10 +37,12 @@ class AdminAuthenticationService(
         return generateAuthResponse(token.adminUser)
     }
 
+    @Transactional
+    fun logout(adminId: UUID) = adminRefreshTokenRepository.removeByAdminUserId(adminId)
+
     private fun generateAuthResponse(adminUser: AdminUser): AuthResponse {
         val accessToken = jwtService.generateToken(adminUser)
         val refreshToken = adminRefreshTokenService.createRefreshToken(adminUser).refreshToken
         return AuthResponse(accessToken, refreshToken)
     }
 }
-

--- a/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
+++ b/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
@@ -16,7 +16,7 @@ import org.springframework.data.repository.findByIdOrNull
 class UserServiceTest {
     private val userRepository: UserRepository = mockk(relaxed = true)
     private val identityImageStorageService: IdentityImageStorageService = mockk(relaxed = true)
-    private val userService = UserService(userRepository, identityImageStorageService)
+    private val userService = UserService(userRepository, identityImageStorageService, "profile-images")
 
     @Test
     fun `findByPhoneNumber() should return User when user exists`() {


### PR DESCRIPTION
## what is the PR Scope ?
implement admin logout endpoint 

## end points with the request and response body:
### logout request
```HTTP
POST /identity/admin/authentication/logout
Authorization: Bearer token
```
### response: just 200 ok