### PR TITLE
Feature/IDN-139 setup localization

### DIFF
--- a/app/src/main/kotlin/net/thechance/config/LocalizationConfig.kt
+++ b/app/src/main/kotlin/net/thechance/config/LocalizationConfig.kt
@@ -1,0 +1,53 @@
+package net.thechance.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.ReloadableResourceBundleMessageSource
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.web.servlet.LocaleResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver
+import java.util.Locale
+
+@Configuration
+class LocalizationConfig : WebMvcConfigurer {
+    @Bean
+    fun localeResolver(): LocaleResolver {
+        return AcceptHeaderLocaleResolver().let { localeResolver ->
+            localeResolver.setDefaultLocale(defaultLocale)
+            localeResolver.supportedLocales = supportedLocales
+            localeResolver
+        }
+    }
+
+    @Bean
+    fun messageSource(): ReloadableResourceBundleMessageSource {
+        return ReloadableResourceBundleMessageSource().let { messageSource ->
+            messageSource.setDefaultEncoding("UTF-8")
+            messageSource.setBasenames(*discoverMessageBaseNames())
+            messageSource
+        }
+    }
+
+    private fun discoverMessageBaseNames(): Array<String> {
+        val resolver = PathMatchingResourcePatternResolver()
+        val resources = resolver.getResources(RESOURCE_PATTERN)
+
+        return resources
+            .mapNotNull { it.filename }
+            .map { filename ->
+                val fileNameWithoutExtension = getFileNameWithoutExtension(filename)
+                "classpath:messages/$fileNameWithoutExtension"
+            }
+            .toSet()
+            .toTypedArray()
+    }
+
+    private fun getFileNameWithoutExtension(filename: String): String = filename.removeSuffix(".properties").substringBeforeLast("_")
+
+    private companion object {
+        private const val RESOURCE_PATTERN = "classpath*:messages/messages-*.properties"
+        private val defaultLocale = Locale.ENGLISH
+        private val supportedLocales = listOf(Locale.ENGLISH, Locale("ar"))
+    }
+}


### PR DESCRIPTION
## what is the PR Scope ?

Added locaization setup

## why do we need that ?

To allow getting data and responses based on `Accept-Language` header

## end points with the request and response body:

N/A

## How to Use

1- Make properties file encoding is UTF-8 not ISO, to be able to store Arabic letters in translation files

<img width="902" height="723" alt="Screenshot 2025-11-04 at 16 36 23" src="https://github.com/user-attachments/assets/63022e26-c6a7-46d1-a615-fae93c61dbf7" />

2- Translation files will be in the following path depending on module name

- `{{module_name}}/src/main/resources/messages/messages-{{module_name}}.properties`
- `{{module_name}}/src/main/resources/messages/messages-{{module_name}}_ar.properties`

For example

- `identity/src/main/resources/messages/messages-identity.properties`
- `identity/src/main/resources/messages/messages-identity_ar.properties`

3- We should follow this naming style `{{module_name}}.hello=Hello World` for messages keys in `messages-{{module_name}}.properties` as duplicating keys is not allowed

For example

`identity.hello=Hello World`

4- Locale can be get anywhere using `LocaleContextHolder.getLocale()` and default is `EN` when no `Accept-Language` header passed in endpoints