### PR TITLE
Fix: IDN-117 remove duplicate '\' from imagesBaseUrl in ProfileController

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
@@ -26,7 +26,7 @@ class ProfileController(
     private val userService: UserService,
     private val changePasswordService: ChangePasswordService
 ) {
-    private val imagesBaseUrl: String = "$cdnEndpoint/$profileImageDirectory"
+    private val imagesBaseUrl: String = "$cdnEndpoint$profileImageDirectory"
 
     @PostMapping
     fun updateUserProfile(
@@ -50,7 +50,7 @@ class ProfileController(
         @RequestPart("file") file: MultipartFile,
     ): ResponseEntity<UpdateImageResponse> {
         val imageUri = userService.updateUserImage(userId, file)
-        val response = UpdateImageResponse(imageUrl = "$imagesBaseUrl$imageUri")
+        val response = UpdateImageResponse(imageUrl = "$imagesBaseUrl/$imageUri")
         return ResponseEntity.ok(response)
     }
 


### PR DESCRIPTION
## what is the PR Scope ?
when we call updateUserImage api it returns wrong urL

## why do we need that ?
to get user profile image after update

## end points response body:
```json
{"imageUrl":"CDN//Directoryimage.jpg?time=2025-11-06T06:40:53.005513381"}
```
## Fix:
```json
{"imageUrl":"CDN/Directory/image.jpg?time=2025-11-06T06:40:53.005513381"}
```