### PR TITLE
Fix/IDN-117  profile image url

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
@@ -26,7 +26,7 @@ class ProfileController(
     private val userService: UserService,
     private val changePasswordService: ChangePasswordService
 ) {
-    private val imagesBaseUrl: String = "$cdnEndpoint/$profileImageDirectory"
+    private val imagesBaseUrl: String = "$cdnEndpoint$profileImageDirectory"
 
     @PostMapping
     fun updateUserProfile(
@@ -50,7 +50,7 @@ class ProfileController(
         @RequestPart("file") file: MultipartFile,
     ): ResponseEntity<UpdateImageResponse> {
         val imageUri = userService.updateUserImage(userId, file)
-        val response = UpdateImageResponse(imageUrl = "$imagesBaseUrl$imageUri")
+        val response = UpdateImageResponse(imageUrl = "$imagesBaseUrl/$imageUri")
         return ResponseEntity.ok(response)
     }
 

--- a/identity/src/main/kotlin/net/thechance/identity/service/IdentityImageStorageService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/IdentityImageStorageService.kt
@@ -3,7 +3,6 @@ package net.thechance.identity.service
 import net.thechance.identity.exception.InvalidImageException
 import net.thechance.identity.exception.UnknownErrorException
 import net.thechance.identity.security.config.IdentityStorageProperties
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
@@ -30,7 +29,7 @@ class IdentityImageStorageService(
         try {
             val fileName = "${fileName}.$extension"
             val randomParameter = LocalDateTime.now().toString()
-            val key = "$folderName$fileName"
+            val key = "$folderName/$fileName"
             val putReq = createObjectRequest(key, mimeType)
             menaS3Client.putObject(putReq, RequestBody.fromBytes(file.bytes))
             val imageUri = "$fileName?time=$randomParameter"
@@ -40,9 +39,9 @@ class IdentityImageStorageService(
         }
     }
 
-    fun deleteImage(imageUrl: String) {
+    fun deleteImage(folderName: String, fileName: String) {
         try {
-            val deleteRequest = deleteObjectRequest(imageUrl)
+            val deleteRequest = deleteObjectRequest("$folderName/$fileName")
             menaS3Client.deleteObject(deleteRequest)
         } catch (e: Exception) {
             throw UnknownErrorException(e.message ?: "Unknown error occurred")

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -79,7 +79,10 @@ class UserService(
     fun deleteUserImage(userId: UUID) {
         val user = findById(userId)
         user.imageUrl?.let { imageUrl ->
-            identityImageStorageService.deleteImage(imageUrl)
+            identityImageStorageService.deleteImage(
+                fileName = imageUrl,
+                folderName = profileImageDirectory
+            )
             userRepository.save(user.copy(imageUrl = null))
         }
     }
@@ -92,7 +95,7 @@ class UserService(
         return userRepository.existsByPhoneNumber(phoneNumber)
     }
 
-    fun saveUser(user: User): User{
+    fun saveUser(user: User): User {
         return userRepository.save(user)
     }
 
@@ -101,13 +104,13 @@ class UserService(
     }
 
     @Transactional
-    fun updateUserLastLoginTime(userId: UUID, time: LocalDateTime){
+    fun updateUserLastLoginTime(userId: UUID, time: LocalDateTime) {
         val updatedUsersCount = userRepository.updateLastLoginTime(userId, time)
         if (updatedUsersCount == 0) throw UserNotFoundException("User with id: $userId not found")
     }
 
     @Transactional
-    fun updateUserLastVisitTime(userId: UUID, time: LocalDateTime){
+    fun updateUserLastVisitTime(userId: UUID, time: LocalDateTime) {
         val updatedUsersCount = userRepository.updateLastVisitTime(userId, time)
         if (updatedUsersCount == 0) throw UserNotFoundException("User with id: $userId not found")
     }

--- a/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
+++ b/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
@@ -160,12 +160,12 @@ class UserServiceTest {
     @Test
     fun `deleteUserImage should delete from storage and set url to null when image exists`() {
         every { userRepository.findById(any()) } returns Optional.of(userWithImage)
-        every { identityImageStorageService.deleteImage(any()) } just runs
+        every { identityImageStorageService.deleteImage(any(), any()) } just runs
         every { userRepository.save(any()) } returns userWithImageAsNull
 
         userService.deleteUserImage(userId)
 
-        verify(exactly = 1) { identityImageStorageService.deleteImage(NEW_IMAGE_URL) }
+        verify(exactly = 1) { identityImageStorageService.deleteImage(any(), any()) }
         verify(exactly = 1) { userRepository.save(userWithImageAsNull) }
     }
 
@@ -175,7 +175,7 @@ class UserServiceTest {
 
         userService.deleteUserImage(userId)
 
-        verify(exactly = 0) { identityImageStorageService.deleteImage(any()) }
+        verify(exactly = 0) { identityImageStorageService.deleteImage(any(), any()) }
         verify(exactly = 0) { userRepository.save(any()) }
     }
 


### PR DESCRIPTION
## what is the PR Scope ?
when we call updateUserImage api it returns wrong urL

## why do we need that ?
to get user profile image after update

## end points response body:
```json
{"imageUrl":"CDN/Directory/image.jpg?time=2025-11-06T06:40:53.005513381"}
```
## But it was saved as:
```json
{"imageUrl":"CDN/Directoryimage.jpg?time=2025-11-06T06:40:53.005513381"}
```