### PR TITLE
return dukan id with the product response

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductResponse.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductResponse.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 data class DukanProductResponse(
     val id: UUID,
     val name:String,
+    val dukanId:UUID,
     val shelfId: UUID,
     val price:Double,
     val description:String,

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
@@ -12,6 +12,7 @@ fun DukanProduct.toProductResponse(quantityInCart: Int): DukanProductResponse {
         description = this.description,
         imageUrls = this.imageUrls,
         quantityInCart = quantityInCart,
-        createdAt = this.createdAt
+        createdAt = this.createdAt,
+        dukanId = this.dukan.id,
     )
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
@@ -14,5 +14,5 @@ fun DukanProductWithFavoriteAndQuantity.toResponse() = DukanProductResponse(
     quantityInCart = this.quantity,
     createdAt = this.product.createdAt,
     isFavorite = this.isFavorite,
-    dukanId = this.dukan.id,
+    dukanId = this.product.dukan.id
     )


### PR DESCRIPTION
## what is the PR Scope ?

add dukan id with the response of product 
## why do we need that ?
we needed this cause we need the dukan id in product details so if the user add to cart of the dukan of this product 

## end points with the request and response body:
NO END POINT 