### PR TITLE
IDN-148-prepare-deeplink-config

### DIFF
--- a/app/src/main/resources/static/.well-known/assetlinks.json
+++ b/app/src/main/resources/static/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.thechance.mena.dev",
+      "sha256_cert_fingerprints": [
+        "C6:53:A2:9B:A1:38:AB:09:4C:E2:0C:07:0E:CC:F7:B3:0F:40:70:BA:74:63:46:04:37:EF:44:CE:B0:B8:B0:17"
+      ]
+    }
+  }
+]

--- a/identity/src/main/kotlin/net/thechance/identity/security/SecurityConfig.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/security/SecurityConfig.kt
@@ -27,7 +27,11 @@ class SecurityConfig(
         http
             .csrf { it.disable() }
             .authorizeHttpRequests {
-                it.requestMatchers("/identity/authentication/**", "/identity/admin/authentication/**").permitAll()
+                it.requestMatchers(
+                    "/identity/authentication/**",
+                    "/identity/admin/authentication/**",
+                    "/.well-known/**"
+                ).permitAll()
                 it.anyRequest().authenticated()
             }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }


### PR DESCRIPTION
## what is the PR Scope ?
add asses links for deeplink configuration

## why do we need that ?
To enable deeplink usage without requiring users to open the settings