### PR TITLE
fix: update audio file naming convention and URL generation

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/service/AttachmentStorageService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/AttachmentStorageService.kt
@@ -58,11 +58,11 @@ class AttachmentStorageService(
         val mimeType = file.contentType ?: throw InvalidAudioFormatException()
         val extension = allowedAudioMimeTypes[mimeType] ?: throw InvalidAudioFormatException()
         try {
-            val finalFileName = "${fileName}_${LocalDateTime.now()}.$extension"
+            val finalFileName = "${LocalDateTime.now()}.$extension"
             val key = "audio/$folderName/$finalFileName"
             val putRequest = createObjectRequest(key, mimeType)
             menaS3Client.putObject(putRequest, RequestBody.fromBytes(file.bytes))
-            return "${props.cdnEndpoint}/$key"
+            return makeUrl(key)
         } catch (e: Exception) {
             throw AudioUploadFailedException("Failed to upload audio file: ${e.message}")
         }


### PR DESCRIPTION
fix audio url
<img width="720" height="195" alt="image" src="https://github.com/user-attachments/assets/388fccb2-5cef-4922-9815-1e1a4360171a" />
