### PR TITLE
Refactor/ return the Pre-signed Url

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/service/FileStorageService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/FileStorageService.kt
@@ -91,8 +91,7 @@ class FileStorageService(
             val presignRequest = getObjectPresignRequest(expirationMinutes, getObjectRequest)
             val presignedRequest = trendsS3Presigner.presignGetObject(presignRequest)
 
-            val fullUrl = presignedRequest.url().toString().substringAfter("://").substringAfter("/")
-            return fullUrl
+            return presignedRequest.url().toString()
 
         }.getOrElse {
             throw TrendUrlSigningException("Failed to generate presigned URL for key: $key")


### PR DESCRIPTION
## what is the PR Scope ?
just small return value fix

return full presigned url instead of splitting it

## why do we need that ?
so that the mobile does not have to map to the cdn

## end points with the request and response body:
no new endpoints