### PR TITLE
fix/TRN-111 fix delete from storage

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/service/FileStorageService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/FileStorageService.kt
@@ -68,14 +68,7 @@ class FileStorageService(
     }
 
     fun deleteFile(fileUrl: String): Boolean {
-        val prefix = trendsStorageProperties.cdnEndpoint
-        if (!fileUrl.startsWith(prefix)) {
-            throw InvalidTrendInputException()
-        }
-
-        val key = fileUrl.removePrefix(prefix)
-
-        val deleteRequest = DeleteObjectRequest.builder().bucket(trendsStorageProperties.bucket).key(key).build()
+        val deleteRequest = DeleteObjectRequest.builder().bucket(trendsStorageProperties.bucket).key(fileUrl).build()
 
         val response = trendsS3Client.deleteObject(deleteRequest)
 


### PR DESCRIPTION
## what is the PR Scope ?
just fixing a minor bug with deleting from storage

## why do we need that ?
since we dont store the full url any more we dont need to delete the prefix at the start

## end points with the request and response body:
no new endpoints