### PR TITLE
add update product to be out of stock 

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductResponse.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductResponse.kt
@@ -13,5 +13,6 @@ data class DukanProductResponse(
     val imageUrls:List<String>,
     val quantityInCart: Int,
     val createdAt: Instant,
-    val isFavorite: Boolean
+    val isFavorite: Boolean,
+    val isOutOfStock: Boolean,
 )

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductUpdateRequest.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/dto/product/DukanProductUpdateRequest.kt
@@ -18,5 +18,7 @@ data class DukanProductUpdateRequest(
     @field:NotNull(message = "must choose at least one shelf")
     val shelfId: UUID,
     @field:Size(min = 1, max = 10, message = "must have at least one image and not execute then 10")
-    val imageUrls: List<String>
+    val imageUrls: List<String>,
+    @field:NotNull(message = "isOutOfStock is required")
+    val isOutOfStock: Boolean,
 )

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductCreationMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductCreationMapper.kt
@@ -23,5 +23,6 @@ fun DukanProductUpdateRequest.toProductUpdateParams(ownerId: UUID, productId : U
         ownerId = ownerId,
         imageUrls = imageUrls,
         productId = productId,
+        isOutOfStock = isOutOfStock,
     )
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/product/DukanProductMapper.kt
@@ -14,5 +14,6 @@ fun DukanProductWithFavoriteAndQuantity.toResponse() = DukanProductResponse(
     quantityInCart = this.quantity,
     createdAt = this.product.createdAt,
     isFavorite = this.isFavorite,
-    dukanId = this.product.dukan.id
+    dukanId = this.product.dukan.id,
+    isOutOfStock = this.product.isOutOfStock,
     )

--- a/dukan/src/main/kotlin/net/thechance/dukan/entity/DukanProduct.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/entity/DukanProduct.kt
@@ -49,5 +49,7 @@ data class DukanProduct(
     val createdAt: Instant = Instant.now(),
 
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
-    val favorites: MutableSet<FavoriteProduct> = emptySet()
+    val favorites: MutableSet<FavoriteProduct> = emptySet(),
+    @Column(name = "is_out_of_stock", nullable = false)
+    val isOutOfStock: Boolean = false,
 )

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanProductService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanProductService.kt
@@ -165,7 +165,8 @@ class DukanProductService(
             price = updateParams.price,
             imageUrls = updateParams.imageUrls,
             description = updateParams.description.trim(),
-            shelf = shelf
+            shelf = shelf,
+            isOutOfStock = updateParams.isOutOfStock,
         )
 
         return dukanProductRepository.save(updatedProduct).id

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/model/DukanProductUpdateParams.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/model/DukanProductUpdateParams.kt
@@ -10,4 +10,5 @@ data class DukanProductUpdateParams (
     val price: Double,
     val ownerId: UUID,
     val imageUrls: List<String>,
+    val isOutOfStock: Boolean,
 )


### PR DESCRIPTION
## what is the PR Scope ?

edit update product to accept updating the product to be out of stock 
## why do we need that ?
we need this as the requirements changed to  accept update product to be out of stock 

## end points with the request and response body:
NO ENDPOINT 