### PR TITLE
refactor: require client generated id for sending messages

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageAudioRequest.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageAudioRequest.kt
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
 data class MessageAudioRequest(
+    val messageId: UUID,
     val chatId: UUID,
     val audio: MultipartFile,
     val audioDurationMs: Long,
@@ -12,6 +13,7 @@ data class MessageAudioRequest(
 
 fun MessageAudioRequest.toRequestArgs(senderId: UUID) =
     MessageAudioRequestArgs(
+        messageId = messageId,
         senderId = senderId,
         chatId = chatId,
         audio = audio,

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageImageRequest.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageImageRequest.kt
@@ -6,11 +6,13 @@ import java.util.*
 
 data class MessageImageRequest(
     val chatId: UUID,
-    val image: MultipartFile
+    val image: MultipartFile,
+    val messageId: UUID,
 )
 
 fun MessageImageRequest.toRequestArgs(senderId: UUID): MessageImageRequestArgs {
     return MessageImageRequestArgs(
+        messageId = messageId,
         chatId = this.chatId,
         senderId = senderId,
         image = this.image

--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/MessageResponse.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.util.*
 
 data class MessageRequestDto(
+    val messageId: UUID,
     val chatId: UUID,
     val text: String?
 )

--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -57,6 +57,7 @@ class ChatService(
     fun saveMessage(args: MessageRequestArgs): Message {
         return messageRepository.save(
             Message(
+                id = args.messageId,
                 senderId = args.senderId,
                 chatId = args.chatId,
                 text = args.text,
@@ -73,6 +74,7 @@ class ChatService(
 
         return messageRepository.save(
             Message(
+                id = args.messageId,
                 senderId = args.senderId,
                 chatId = args.chatId,
                 imageUrl = imageUrl
@@ -90,6 +92,7 @@ class ChatService(
 
         return messageRepository.save(
             Message(
+                id = args.messageId,
                 senderId = args.senderId,
                 chatId = args.chatId,
                 audioUrl = audioUrl,

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/MessageAudioRequestArgs.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/MessageAudioRequestArgs.kt
@@ -4,6 +4,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
 data class MessageAudioRequestArgs(
+    val messageId: UUID,
     val senderId: UUID,
     val chatId: UUID,
     val audio: MultipartFile,

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/MessageImageRequestArgs.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/MessageImageRequestArgs.kt
@@ -4,6 +4,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
 data class MessageImageRequestArgs(
+    val messageId: UUID,
     val chatId: UUID,
     val senderId: UUID,
     val image: MultipartFile

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/MessageRequestArgs.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/MessageRequestArgs.kt
@@ -5,6 +5,7 @@ import java.util.*
 
 
 data class MessageRequestArgs(
+    val messageId: UUID,
     val chatId: UUID,
     val senderId: UUID,
     val text: String?
@@ -12,6 +13,7 @@ data class MessageRequestArgs(
 
 fun MessageRequestDto.toRequestArgs(senderId: UUID): MessageRequestArgs {
     return MessageRequestArgs(
+        messageId = messageId,
         chatId = this.chatId,
         senderId = senderId,
         text = this.text


### PR DESCRIPTION
## what is the PR Scope ?
sending messages

## why do we need that ?
we need to let the client generate the uuid for massages, so he can always sync and check if messages are sent successfully

## end points with the request and response body:
no new endpoint, just add one parameter (messageId: UUID) to three end point (send text message endpoint, send audio message endpoint, and send image message endpoint)