### PR TITLE
fix:DKN-153-fix-return-dukanid-in-product-search-result

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/eventListener/ProductEventListener.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/eventListener/ProductEventListener.kt
@@ -25,7 +25,8 @@ class ProductEventListener(
             id = event.id,
             name = event.name,
             price = event.price,
-            dukanName = event.description,
+            dukanName = event.dukanName,
+            dukanId = event.dukanId,
             mainImageUrl = event.mainImageUrl,
             shelfName = event.shelfName
         )

--- a/dukan/src/main/kotlin/net/thechance/dukan/search/document/ProductDocument.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/search/document/ProductDocument.kt
@@ -19,6 +19,9 @@ data class ProductDocument(
     val dukanName:String,
 
     @Field(type = FieldType.Text)
+    val dukanId:String,
+
+    @Field(type = FieldType.Text)
     val mainImageUrl:String,
 
     @Field(type = FieldType.Text)

--- a/dukan/src/main/kotlin/net/thechance/dukan/search/mpper/ProductDocumentMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/search/mpper/ProductDocumentMapper.kt
@@ -10,6 +10,7 @@ fun DukanProduct.toDocument():ProductDocument{
         name = name,
         price = price,
         dukanName = dukan.name,
+        dukanId = dukan.id.toString(),
         mainImageUrl = imageUrls.first(),
         shelfName = shelf.title
     )
@@ -21,6 +22,7 @@ fun ProductDocument.toSearchResultPreviewItem(isFavorite:Boolean = false):Produc
         id = id,
         name = name,
         dukanName = dukanName,
+        dukanId = dukanId,
         price = price,
         mainImageUrl = mainImageUrl,
         isFavorite = isFavorite

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/DukanProductService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/DukanProductService.kt
@@ -85,7 +85,8 @@ class DukanProductService(
     private fun DukanProduct.toProductSaveEvent() = ProductEvent.Save(
         id = this.id.toString(),
         name = this.name,
-        description = this.description,
+        dukanName = this.description,
+        dukanId = this.dukan.id.toString(),
         mainImageUrl = this.imageUrls.firstOrNull().orEmpty(),
         price = this.price,
         shelfName = this.shelf.title

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/model/ProductSearchResultPreview.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/model/ProductSearchResultPreview.kt
@@ -4,6 +4,7 @@ data class ProductSearchResultPreview(
     val id:String,
     val name :String,
     val dukanName:String,
+    val dukanId:String,
     val price:Double,
     val mainImageUrl:String,
     val isFavorite:Boolean = false

--- a/events/src/main/kotlin/net/thechance/events/dukan/ProductEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/ProductEvent.kt
@@ -7,7 +7,8 @@ sealed class ProductEvent: MenaEvent {
         val id: String,
         val name: String,
         val price: Double,
-        val description: String,
+        val dukanName: String,
+        val dukanId:String,
         val mainImageUrl: String,
         val shelfName: String
     ):ProductEvent()


### PR DESCRIPTION
## what is the PR Scope ?
product search end point 

## why do we need that ?
we need the dukan id in the product preview item so we can use it to the dukan cart 

## end points with the request and response body:
endpoint : 
dukan/products/search?query=t&page=0&size=20




response:
{
  "totalElements": 216,
  "totalPages": 11,
  "first": true,
  "last": false,
  "size": 20,
  "content": [
    {
      "id": "1e2b7fb6-90a0-4cbf-b680-45601751be6f",
      "name": "Product 3",
      "dukanName": "Demo Dukan",
      "dukanId": "ca64095d-4e53-426d-bdc7-cff205b743a4",
      "price": 13.8237090146631,
      "mainImageUrl": "https://picsum.photos/200/200?random=3",
      "isFavorite": false
    }
.
.
.
.
.
.