### PR TITLE
Feature: TRN-118 Get Favorite Trends

### DIFF
--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendsController.kt
@@ -44,14 +44,16 @@ class TrendsController(
         return ResponseEntity.ok(result)
     }
 
-    @GetMapping("/favorites")
+    @GetMapping("/favorites", "/favorites/{trendsId}")
     fun getFavoriteTrends(
         pageable: Pageable,
+        @PathVariable(required = false) trendsId: UUID? = null,
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<TrendResponse>> {
         val trends = trendsService.getUserFavoriteTrends(
-            pageable,
-            currentUserId
+            pageable = pageable,
+            currentUserId = currentUserId,
+            trendId = trendsId,
         ).content.map { trend -> trend.toResponse() }
 
         val result = PagingResponse(

--- a/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendsController.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/controller/TrendsController.kt
@@ -2,11 +2,7 @@ package net.thechance.trends.api.controller
 
 import jakarta.validation.Valid
 import net.thechance.trends.api.dto.base.PagingResponse
-import net.thechance.trends.api.dto.trend.TrendPathsResponse
-import net.thechance.trends.api.dto.trend.TrendResponse
-import net.thechance.trends.api.dto.trend.UpdateTrendRequest
-import net.thechance.trends.api.dto.trend.UploadTrendResponse
-import net.thechance.trends.api.dto.trend.toResponse
+import net.thechance.trends.api.dto.trend.*
 import net.thechance.trends.service.TrendsService
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -38,6 +34,25 @@ class TrendsController(
         @AuthenticationPrincipal currentUserId: UUID
     ): ResponseEntity<PagingResponse<TrendResponse>> {
         val trends = trendsService.getAllTrendsForFeed(pageable, currentUserId, trendsId).content.map { trend -> trend.toResponse() }
+
+        val result = PagingResponse(
+            pageNumber = pageable.pageNumber,
+            results = trends,
+            totalResults = trends.size
+        )
+
+        return ResponseEntity.ok(result)
+    }
+
+    @GetMapping("/favorites")
+    fun getFavoriteTrends(
+        pageable: Pageable,
+        @AuthenticationPrincipal currentUserId: UUID
+    ): ResponseEntity<PagingResponse<TrendResponse>> {
+        val trends = trendsService.getUserFavoriteTrends(
+            pageable,
+            currentUserId
+        ).content.map { trend -> trend.toResponse() }
 
         val result = PagingResponse(
             pageNumber = pageable.pageNumber,

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
@@ -130,16 +130,24 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
     FROM Trend t
     INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
     WHERE t.isPublished = true
+    AND (:trendId IS NULL OR t.createdAt <= (
+        SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+    ))
     """,
         countQuery = """
     SELECT COUNT(DISTINCT t.id)
     FROM Trend t
     INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
     WHERE t.isPublished = true
+    AND (:trendId IS NULL OR t.createdAt <= (
+        SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+    ))
     """
     )
     fun getUserLikedTrends(
         userId: UUID,
+        trendId: UUID?,
         pageable: Pageable
     ): Page<TrendWithLikeStatus>
+
 }

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
@@ -34,7 +34,12 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
         ))
         """
     )
-    fun findByOwnerIdAndIsPublished(ownerId: UUID, isPublished: Boolean, trendId: UUID?, pageable: Pageable): Page<TrendWithLikeStatus>
+    fun findByOwnerIdAndIsPublished(
+        ownerId: UUID,
+        isPublished: Boolean,
+        trendId: UUID?,
+        pageable: Pageable
+    ): Page<TrendWithLikeStatus>
 
     @Query(
         """
@@ -114,6 +119,27 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
     fun getTrendFeedForUser(
         userId: UUID,
         trendId: UUID?,
+        pageable: Pageable
+    ): Page<TrendWithLikeStatus>
+
+
+    @Query(
+        """
+    SELECT DISTINCT t AS trend, 
+           true AS isLiked
+    FROM Trend t
+    INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
+    WHERE t.isPublished = true
+    """,
+        countQuery = """
+    SELECT COUNT(DISTINCT t.id)
+    FROM Trend t
+    INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
+    WHERE t.isPublished = true
+    """
+    )
+    fun getUserLikedTrends(
+        userId: UUID,
         pageable: Pageable
     ): Page<TrendWithLikeStatus>
 }

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
@@ -77,6 +77,7 @@ class TrendsService(
     fun getUserFavoriteTrends(
         pageable: Pageable,
         currentUserId: UUID,
+        trendId: UUID? = null,
     ): Page<TrendWithOwnerShipAndLikeStatus> {
         val adjustedPageable = PageRequest.of(
             pageable.pageNumber,
@@ -85,7 +86,7 @@ class TrendsService(
         )
 
         return trendsRepository
-            .getUserLikedTrends(currentUserId, adjustedPageable)
+            .getUserLikedTrends(currentUserId, trendId, adjustedPageable)
             .map {
                 generatePresignedUrlsForTrend(it)
                     .withOwnership(currentUserId)

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendsService.kt
@@ -74,6 +74,24 @@ class TrendsService(
         return trends
     }
 
+    fun getUserFavoriteTrends(
+        pageable: Pageable,
+        currentUserId: UUID,
+    ): Page<TrendWithOwnerShipAndLikeStatus> {
+        val adjustedPageable = PageRequest.of(
+            pageable.pageNumber,
+            10,
+            pageable.getSortOr(Sort.by(Sort.Direction.DESC, "createdAt"))
+        )
+
+        return trendsRepository
+            .getUserLikedTrends(currentUserId, adjustedPageable)
+            .map {
+                generatePresignedUrlsForTrend(it)
+                    .withOwnership(currentUserId)
+            }
+    }
+
     @Transactional
     fun deleteTrendById(id: UUID, currentUserId: UUID) {
         val trendUrls = trendsRepository.findVideoUrlByIdAndOwnerId(id, currentUserId)
@@ -149,7 +167,11 @@ class TrendsService(
     }
 
     fun getTrendOrThrow(trendId: UUID, userId: UUID): TrendWithLikeStatus {
-        return trendsRepository.findByIdAndIsPublishedWithLikeStatus(trendId = trendId, isPublished = true, userId = userId) ?: throw TrendNotFoundException()
+        return trendsRepository.findByIdAndIsPublishedWithLikeStatus(
+            trendId = trendId,
+            isPublished = true,
+            userId = userId
+        ) ?: throw TrendNotFoundException()
     }
 
     private fun generatePresignedUrlsForTrend(
@@ -171,7 +193,7 @@ class TrendsService(
         }
     }
 
-    private fun createTrendWithLikeStatus(trend: Trend, isLiked: Boolean): TrendWithLikeStatus{
+    private fun createTrendWithLikeStatus(trend: Trend, isLiked: Boolean): TrendWithLikeStatus {
         return object : TrendWithLikeStatus {
             override fun getTrend(): Trend = trend
             override fun getIsLiked(): Boolean = isLiked


### PR DESCRIPTION
## What is the PR Scope?

This PR adds a new endpoint to retrieve the current user's favorite trends. The changes include:

- Added new `GET /trends/favorites` endpoint to fetch trends that the user has liked
- Added repository method to query liked trends for a specific user
- Added service method to handle business logic for fetching favorite trends
- Maintained consistent pagination and response structure with existing trends endpoints

## Why do we need that?

The application currently lacks the ability for users to view their liked/favorited trends in one place. This feature is essential as it allows users to easily access trends they've previously liked


## Endpoints with the request and response body:

**Endpoint:** `GET /trends/favorites`

**Request Headers:**
- Authentication: Bearer token required

**Query Parameters:**
- `page` (optional) - page number for pagination (default: 0)
- `size` (optional) - number of items per page (default: 10)

**Example Request:**
```bash
curl --request GET \
  --url 'http://localhost:8080/trends/favorites?size=10&page=0' \
  --header 'authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJiOWUwOGI2YS1kZGFlLTQ3MzgtYTQ0MS1jYmUxZDFkNzhhMmUiLCJpYXQiOjE3NjI4NDU2NjQsImV4cCI6MTc2Mjg0OTI2NH0.2lcDTgwxlES9ztqFtMCtYIJZkjqux352J5WfTfBbccUp2LU1knC6_5mTMkVUJHMr'
  ```
  
  **Example Response:**
  ```json
  {
  "pageNumber": 0,
  "results": [
    {
      "trendId": "c327735c-2995-492f-80c8-b7c55b0887ee",
      "thumbnailUrl": "https://s3.tebi.io/mena-trends/thumbnail/2025-11-07T12:58:57.651232700.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20251111T074311Z&X-Amz-SignedHeaders=host%3Bx-access-key&X-Amz-Credential=H2yyZDwD4alwUhDJ%2F20251111%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=300&X-Amz-Signature=def1761f0812d1cc0411f7d99b633f20aa97012e65d3c6de9e92538addc966bc",
      "videoUrl": "https://s3.tebi.io/mena-trends/video/2025-11-07T12:57:59.170508800.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20251111T074311Z&X-Amz-SignedHeaders=host%3Bx-access-key&X-Amz-Credential=H2yyZDwD4alwUhDJ%2F20251111%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=300&X-Amz-Signature=d44cb6f95c9c31537958ecaca4cde062c3046ea8c7f41da436d7da92c3956953",
      "description": "",
      "createdAt": "2025-11-07T12:58:56.14233",
      "likesCount": 1,
      "viewsCount": 1,
      "isLiked": true,
      "isCurrentUserOwner": true,
      "username": "The Chance",
      "profilePictureUrl": ""
    }
  ],
  "totalResults": 1
}
```