### PR TITLE
Fix/FTH-161 change tilawah methods that have body to QueryParams

### DIFF
--- a/faith/src/main/kotlin/net/thechance/faith/api/controller/TilawahController.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/api/controller/TilawahController.kt
@@ -8,8 +8,6 @@ import net.thechance.faith.api.dto.tilawah.toResponse
 import net.thechance.faith.service.tilawah.TilawahService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -25,27 +23,25 @@ class TilawahController(
         return ResponseEntity.ok(reciters.toResponse())
     }
 
-    @PostMapping("/ayah/sound")
+    @GetMapping("/ayah/sound")
     fun getAyahSoundUrl(
-        @Valid @RequestBody
-        ayahSoundRequest: AyahSoundRequest
+        @Valid request: AyahSoundRequest,
     ): ResponseEntity<String> {
         val soundUrl = recitersService.getAyahSoundUrl(
-            reciterId = ayahSoundRequest.reciterId,
-            surahNumber = ayahSoundRequest.surahNumber,
-            ayahNumber = ayahSoundRequest.ayahNumber
+            reciterId = request.reciterId,
+            surahNumber = request.surahNumber,
+            ayahNumber = request.ayahNumber
         )
         return ResponseEntity.ok(soundUrl)
     }
 
-    @PostMapping("/surah/sound")
+    @GetMapping("/surah/sound")
     fun getSurahSoundUrl(
-        @Valid @RequestBody
-        surahSoundRequest: SurahSoundRequest
+        @Valid request: SurahSoundRequest,
     ): ResponseEntity<String> {
         val soundUrl = recitersService.getSurahSoundsUrl(
-            reciterId = surahSoundRequest.reciterId,
-            surahNumber = surahSoundRequest.surahNumber,
+            reciterId = request.reciterId,
+            surahNumber = request.surahNumber,
         )
         return ResponseEntity.ok(soundUrl)
     }

--- a/faith/src/main/kotlin/net/thechance/faith/api/controller/TilawahController.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/api/controller/TilawahController.kt
@@ -8,6 +8,7 @@ import net.thechance.faith.api.dto.tilawah.toResponse
 import net.thechance.faith.service.tilawah.TilawahService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -24,7 +25,7 @@ class TilawahController(
         return ResponseEntity.ok(reciters.toResponse())
     }
 
-    @GetMapping("/ayah/sound")
+    @PostMapping("/ayah/sound")
     fun getAyahSoundUrl(
         @Valid @RequestBody
         ayahSoundRequest: AyahSoundRequest
@@ -37,7 +38,7 @@ class TilawahController(
         return ResponseEntity.ok(soundUrl)
     }
 
-    @GetMapping("/surah/sound")
+    @PostMapping("/surah/sound")
     fun getSurahSoundUrl(
         @Valid @RequestBody
         surahSoundRequest: SurahSoundRequest


### PR DESCRIPTION
## what is the PR Scope ?
Tilawah Http requests change from taking a body requst into a query parameters.

## why do we need that ?
Get methods should not have a body, instead it should have a query parameters.

## end points with the request and response body:
<img width="1045" height="676" alt="image" src="https://github.com/user-attachments/assets/583051a5-4132-439c-8e86-a04e5ecb66e0" />

