### PR TITLE
fix: Change creatorId from primary key to regular column in Mosque en…

### DIFF
--- a/faith/src/main/kotlin/net/thechance/faith/entity/Mosque.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/entity/Mosque.kt
@@ -11,7 +11,7 @@ data class Mosque(
     @GeneratedValue(strategy = GenerationType.UUID)
     val id: UUID = UUID.randomUUID(),
 
-    @Id
+    @Column(nullable = false)
     val creatorId: UUID,
 
     @Column(nullable = false)


### PR DESCRIPTION

## what is the PR Scope ?
Change creatorId from primary key to regular column in Mosque entity

## why do we need that ?


## end points with the request and response body:
