### PR TITLE
feature: add contact info

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/settings/SettingsController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/settings/SettingsController.kt
@@ -1,7 +1,9 @@
 package net.thechance.identity.api.controller.settings
 
+import net.thechance.identity.api.dto.settings.ContactInfoResponse
 import net.thechance.identity.api.dto.settings.PrivacyAndPolicyResponse
 import net.thechance.identity.api.mapper.toResponse
+import net.thechance.identity.service.ContactInfoService
 import net.thechance.identity.service.PrivacyAndPolicyService
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.ResponseEntity
@@ -13,11 +15,18 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/identity/settings")
 class SettingsController(
     private val privacyAndPolicyService: PrivacyAndPolicyService,
+    private val contactInfoService: ContactInfoService,
 ) {
     @GetMapping("/privacy-and-policy")
     fun getPrivacyAndPolicy(): ResponseEntity<PrivacyAndPolicyResponse> {
         val language = LocaleContextHolder.getLocale().language
         val privacyAndPolicy = privacyAndPolicyService.getPrivacyAndPolicy(language)
         return ResponseEntity.ok(privacyAndPolicy.toResponse())
+    }
+
+    @GetMapping("/contact-info")
+    fun getContactInfo(): ResponseEntity<ContactInfoResponse> {
+        val contactInfo = contactInfoService.getContactInfo()
+        return ResponseEntity.ok(contactInfo.toResponse())
     }
 }

--- a/identity/src/main/kotlin/net/thechance/identity/api/dto/settings/ContactInfoResponse.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/dto/settings/ContactInfoResponse.kt
@@ -1,0 +1,7 @@
+package net.thechance.identity.api.dto.settings
+
+class ContactInfoResponse(
+    val email: String,
+    val phoneNumber: String,
+    val facebookAccount: String,
+)

--- a/identity/src/main/kotlin/net/thechance/identity/api/mapper/ContactInfoMapper.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/mapper/ContactInfoMapper.kt
@@ -1,0 +1,6 @@
+package net.thechance.identity.api.mapper
+
+import net.thechance.identity.api.dto.settings.ContactInfoResponse
+import net.thechance.identity.service.model.ContactInfoModel
+
+fun ContactInfoModel.toResponse() = ContactInfoResponse(email = email, phoneNumber = phoneNumber, facebookAccount = facebookAccount )

--- a/identity/src/main/kotlin/net/thechance/identity/service/ContactInfoService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/ContactInfoService.kt
@@ -1,0 +1,21 @@
+package net.thechance.identity.service
+
+import net.thechance.identity.service.model.ContactInfoModel
+import org.springframework.stereotype.Service
+
+@Service
+class ContactInfoService {
+    fun getContactInfo(): ContactInfoModel {
+        return ContactInfoModel(
+            email = EMAIL,
+            phoneNumber = PHONE_NUMBER,
+            facebookAccount = FACEBOOK_ACCOUNT
+        )
+    }
+
+    companion object {
+        private const val EMAIL = "MENA2025@gmail.com"
+        private const val PHONE_NUMBER = "+964 770 0000 000"
+        private const val FACEBOOK_ACCOUNT = "https://www.facebook.com"
+    }
+}

--- a/identity/src/main/kotlin/net/thechance/identity/service/model/ContactInfoModel.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/model/ContactInfoModel.kt
@@ -1,0 +1,7 @@
+package net.thechance.identity.service.model
+
+data class ContactInfoModel(
+    val email: String,
+    val phoneNumber: String,
+    val facebookAccount: String,
+)

--- a/identity/src/test/kotlin/net/thechance/identity/service/ContactInfoServiceTest.kt
+++ b/identity/src/test/kotlin/net/thechance/identity/service/ContactInfoServiceTest.kt
@@ -1,0 +1,24 @@
+package net.thechance.identity.service
+
+import com.google.common.truth.Truth.assertThat
+import net.thechance.identity.service.model.ContactInfoModel
+import org.junit.Test
+
+class ContactInfoServiceTest {
+    private val contactInfoService = ContactInfoService()
+
+    @Test
+    fun `getContactInfo() should return contact info`() {
+        val result = contactInfoService.getContactInfo()
+
+        assertThat(result).isEqualTo(contactInfo)
+    }
+
+    companion object {
+        private val contactInfo = ContactInfoModel(
+            email = "MENA2025@gmail.com",
+            phoneNumber = "+964 770 0000 000",
+            facebookAccount = "https://www.facebook.com"
+        )
+    }
+}


### PR DESCRIPTION
## What is the PR Scope ?

Added Contact Info Endpoint

## Why do we need that ?

- `/identity/settings/contact-info` to allow the user to get contact info

## Endpoints with the request and response body:

- Endpoint: `/identity/settings/contact-info`

Curl:
`curl --location 'https://mena-dev.the-chance.net/identity/settings/contact-info'`

RequestBody: 
`No Body`

Expected returned body:
```json
{
    "email": "MENA2025@gmail.com",
    "phoneNumber": "+964 770 0000 000",
    "facebookAccount": "https://www.facebook.com"
}
```
