### PR TITLE
fix: make regex accept multiple name

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/dto/shelf/DukanShelfTitleRequest.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/dto/shelf/DukanShelfTitleRequest.kt
@@ -7,7 +7,7 @@ data class DukanShelfTitleRequest(
     @field:NotBlank
     @field:Size(max = 50, message = "name must not exceed 50 characters")
     @field:Pattern(
-        regexp = "^[A-Za-z-]+$",
+        regexp = "^[\\p{L}0-9]+(\\s[\\p{L}0-9]+)*$",
         message = "name can only contain letters and '-'"
     )
     val title: String,


### PR DESCRIPTION
## what is the PR Scope ?
fix  dukan shelf name 

## why do we need that ?
for dukan shelf can accept multiple name

## end points with the request and response body:
**when regex didnt accept  multiple name**
<img width="833" height="754" alt="image" src="https://github.com/user-attachments/assets/328158d5-c0fd-4039-b28a-27d33f81156a" />

**after** 
<img width="833" height="754" alt="image" src="https://github.com/user-attachments/assets/c7026f7a-84c6-48d3-b1c1-70de9de352a3" />
<img width="833" height="754" alt="image" src="https://github.com/user-attachments/assets/082e6dbb-bf7e-446e-bfa2-66e38661fcef" />

