### PR TITLE
Feature/IDN-215 add logout endpoint

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/identity/IdentityController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/identity/IdentityController.kt
@@ -18,6 +18,7 @@ import net.thechance.identity.service.RegisterService
 import net.thechance.identity.service.ResetPasswordService
 import net.thechance.identity.service.UserService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -124,5 +125,11 @@ class IdentityController(
     fun getSupportedCountries(): ResponseEntity<List<CountryResponse>> {
         val response = authenticationService.getCountries().toCountryResponses()
         return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/logout")
+    fun logout(@AuthenticationPrincipal userId: UUID): ResponseEntity<Unit> {
+        authenticationService.logout(userId)
+        return ResponseEntity.ok().build()
     }
 }

--- a/identity/src/main/kotlin/net/thechance/identity/security/SecurityConfig.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/security/SecurityConfig.kt
@@ -27,6 +27,7 @@ class SecurityConfig(
         http
             .csrf { it.disable() }
             .authorizeHttpRequests {
+                it.requestMatchers("/identity/authentication/logout").authenticated()
                 it.requestMatchers(
                     "/identity/authentication/**",
                     "/identity/admin/authentication/**",


### PR DESCRIPTION
## What is the PR Scope ?

Added logout Endpoint

## Why do we need that ?

- `/identity/authentication/logout` to allow the user to logout

## Endpoints with the request and response body:

- Endpoint: `/identity/authentication/logout`

Request Body: 
`No Body`

Expected Returned Body:
`No Body`
