### PR TITLE
Feature/cht 128 save user in chat based on user events

### DIFF
--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation(platform("software.amazon.awssdk:bom:2.33.8"))
     implementation("software.amazon.awssdk:s3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    implementation(project(":events"))
 }
 
 tasks.test {

--- a/chat/src/main/kotlin/net/thechance/chat/eventListener/ChatEventListener.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/eventListener/ChatEventListener.kt
@@ -1,0 +1,21 @@
+package net.thechance.chat.eventListener
+
+import net.thechance.chat.eventListener.mapper.toUser
+import net.thechance.chat.repository.ContactUserRepository
+import net.thechance.events.identity.UserCreatedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class ChatEventListener(
+    private val userRepository: ContactUserRepository
+) {
+
+
+    @EventListener
+    @Async
+    fun onUserCreatedEvent(event: UserCreatedEvent) {
+        userRepository.save(event.toUser())
+    }
+}

--- a/chat/src/main/kotlin/net/thechance/chat/eventListener/ChatEventListener.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/eventListener/ChatEventListener.kt
@@ -3,6 +3,7 @@ package net.thechance.chat.eventListener
 import net.thechance.chat.eventListener.mapper.toUser
 import net.thechance.chat.repository.ContactUserRepository
 import net.thechance.events.identity.UserCreatedEvent
+import net.thechance.events.identity.UserUpdatedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -16,6 +17,12 @@ class ChatEventListener(
     @EventListener
     @Async
     fun onUserCreatedEvent(event: UserCreatedEvent) {
+        userRepository.save(event.toUser())
+    }
+
+    @EventListener
+    @Async
+    fun onUserUpdatedEvent(event: UserUpdatedEvent){
         userRepository.save(event.toUser())
     }
 }

--- a/chat/src/main/kotlin/net/thechance/chat/eventListener/mapper/UserCreatedEventMapper.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/eventListener/mapper/UserCreatedEventMapper.kt
@@ -1,0 +1,15 @@
+package net.thechance.chat.eventListener.mapper
+
+import net.thechance.chat.entity.ContactUser
+import net.thechance.events.identity.UserCreatedEvent
+
+fun UserCreatedEvent.toUser(): ContactUser {
+    return ContactUser(
+        id = id,
+        firstName = firstName,
+        lastName = lastName,
+        phoneNumber = phoneNumber,
+        imageUrl = imageUrl
+    )
+}
+

--- a/chat/src/main/kotlin/net/thechance/chat/eventListener/mapper/UserUpdateEventMapper.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/eventListener/mapper/UserUpdateEventMapper.kt
@@ -1,0 +1,14 @@
+package net.thechance.chat.eventListener.mapper
+
+import net.thechance.chat.entity.ContactUser
+import net.thechance.events.identity.UserUpdatedEvent
+
+fun UserUpdatedEvent.toUser(): ContactUser{
+    return ContactUser(
+        id = id,
+        firstName = firstName,
+        lastName = lastName,
+        phoneNumber = phoneNumber,
+        imageUrl = imageUrl
+    )
+}


### PR DESCRIPTION
## what is the PR Scope ?
save new user information based on userCreatedEvent

## why do we need that ?
to save user information in our chat schema user table when new user make a mena account

## end points with the request and response body:
no special endpoints