### PR TITLE
feat: integrating event bus with the trend response

### DIFF
--- a/trends/build.gradle.kts
+++ b/trends/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation(platform("software.amazon.awssdk:bom:2.33.8"))
     implementation("software.amazon.awssdk:s3")
+    implementation(project(":events"))
 }
 
 kover.reports {

--- a/trends/src/main/kotlin/net/thechance/trends/api/dto/trend/TrendResponse.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/api/dto/trend/TrendResponse.kt
@@ -15,8 +15,8 @@ data class TrendResponse(
     val viewsCount: Int,
     val isLiked: Boolean,
     val isCurrentUserOwner: Boolean,
-    val username: String = "The Chance",
-    val profilePictureUrl: String = "",
+    val username: String,
+    val profilePictureUrl: String?
 )
 
 fun Trend.toResponse(isLiked: Boolean = false): TrendResponse {
@@ -29,7 +29,9 @@ fun Trend.toResponse(isLiked: Boolean = false): TrendResponse {
         likesCount = likesCount,
         viewsCount = viewsCount,
         isCurrentUserOwner = false,
-        isLiked = isLiked
+        isLiked = isLiked,
+        username = owner?.username ?: "Unknown",
+        profilePictureUrl = owner?.imageUrl
     )
 }
 
@@ -43,6 +45,8 @@ fun TrendWithOwnerShipAndLikeStatus.toResponse(): TrendResponse {
         likesCount = likesCount,
         viewsCount = viewsCount,
         isCurrentUserOwner = isCurrentUserOwner,
-        isLiked = isLiked
+        isLiked = isLiked,
+        username = username,
+        profilePictureUrl = profileImageUrl
     )
 }

--- a/trends/src/main/kotlin/net/thechance/trends/entity/Trend.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/entity/Trend.kt
@@ -16,10 +16,17 @@ data class Trend(
 
     @Column(name = "owner_id", nullable = false)
     val ownerId: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", referencedColumnName = "user_id", insertable = false, updatable = false)
+    val owner: TrendUser? = null,
+
     @Column(name = "thumbnail_url", nullable = true, columnDefinition = "TEXT")
     val thumbnailUrl: String? = null,
+
     @Column(name = "video_url", nullable = false, columnDefinition = "TEXT")
     val videoUrl: String,
+
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     val description: String = "",
 

--- a/trends/src/main/kotlin/net/thechance/trends/entity/TrendUser.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/entity/TrendUser.kt
@@ -8,8 +8,23 @@ import java.util.Collections.emptySet
 @Entity
 data class TrendUser(
     @Id
-    @Column(columnDefinition = "uuid", nullable = false, updatable = false)
+    @Column(name = "user_id", columnDefinition = "uuid", nullable = false, updatable = false)
     val userId: UUID,
+
+    @Column(name = "phone_number", nullable = false, unique = true)
+    val phoneNumber: String,
+
+    @Column(name = "first_name", nullable = false)
+    val firstName: String,
+
+    @Column(name = "last_name", nullable = false)
+    val lastName: String,
+
+    @Column(name = "username", nullable = false, unique = true)
+    val username: String,
+
+    @Column(name = "image_url", nullable = true, length = 2083)
+    val imageUrl: String?,
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
@@ -19,4 +34,13 @@ data class TrendUser(
         schema = "trends",
     )
     val categories: MutableSet<Category> = emptySet(),
-)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: Status
+) {
+    enum class Status {
+        ACTIVE,
+        BLOCKED
+    }
+}

--- a/trends/src/main/kotlin/net/thechance/trends/eventListener/TrendEventListener.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/eventListener/TrendEventListener.kt
@@ -1,0 +1,65 @@
+package net.thechance.trends.eventListener
+
+import net.thechance.events.identity.UserCreatedEvent
+import net.thechance.events.identity.UserStatusUpdatedEvent
+import net.thechance.events.identity.UserUpdatedEvent
+import net.thechance.trends.entity.TrendUser
+import net.thechance.trends.repository.TrendUserRepository
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import net.thechance.events.identity.utils.Status as EventStatus
+import net.thechance.trends.entity.TrendUser.Status as TrendUserStatus
+
+@Component
+class TrendEventListener(
+    private val userRepository: TrendUserRepository
+) {
+
+    private fun EventStatus.toTrendUserStatus(): TrendUserStatus {
+        return when (this) {
+            EventStatus.ACTIVE -> TrendUserStatus.ACTIVE
+            EventStatus.BLOCKED -> TrendUserStatus.BLOCKED
+        }
+    }
+
+    @EventListener
+    @Async
+    fun handleUserCreated(event: UserCreatedEvent) {
+        val trendUser = TrendUser(
+            userId = event.id,
+            phoneNumber = event.phoneNumber,
+            firstName = event.firstName,
+            lastName = event.lastName,
+            username = event.username,
+            imageUrl = event.imageUrl,
+            status = event.status.toTrendUserStatus()
+        )
+        userRepository.save(trendUser)
+    }
+
+    @EventListener
+    @Async
+    fun handleUserUpdated(event: UserUpdatedEvent) {
+        val trendUser = TrendUser(
+            userId = event.id,
+            phoneNumber = event.phoneNumber,
+            firstName = event.firstName,
+            lastName = event.lastName,
+            username = event.username,
+            imageUrl = event.imageUrl,
+            status = event.status.toTrendUserStatus()
+        )
+        userRepository.save(trendUser)
+    }
+
+    @EventListener
+    @Async
+    fun handleUserStatusUpdated(event: UserStatusUpdatedEvent) {
+        val status = when (event.status) {
+            UserStatusUpdatedEvent.UserStatus.BLOCKED -> TrendUserStatus.BLOCKED
+            UserStatusUpdatedEvent.UserStatus.ACTIVE -> TrendUserStatus.ACTIVE
+        }
+        userRepository.updateUserStatus(event.userId, status)
+    }
+}

--- a/trends/src/main/kotlin/net/thechance/trends/models/TrendWithOwnerShipAndLikeStatus.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/models/TrendWithOwnerShipAndLikeStatus.kt
@@ -13,11 +13,15 @@ data class TrendWithOwnerShipAndLikeStatus(
     val viewsCount: Int,
     val isLiked: Boolean,
     val isCurrentUserOwner: Boolean,
+    val username: String,
+    val profileImageUrl: String?
 )
 
 fun TrendWithLikeStatus.withOwnership(currentUserId: UUID): TrendWithOwnerShipAndLikeStatus {
     val trend = getTrend()
+    val owner = trend.owner
     val isLiked = getIsLiked()
+
     return TrendWithOwnerShipAndLikeStatus(
         trendId = trend.id,
         thumbnailUrl = trend.thumbnailUrl,
@@ -27,6 +31,8 @@ fun TrendWithLikeStatus.withOwnership(currentUserId: UUID): TrendWithOwnerShipAn
         likesCount = trend.likesCount,
         viewsCount = trend.viewsCount,
         isLiked = isLiked,
-        isCurrentUserOwner = currentUserId == trend.ownerId
+        isCurrentUserOwner = currentUserId == trend.ownerId,
+        username = owner?.username?: "Unknown" ,
+        profileImageUrl = owner?.imageUrl
     )
 }

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendUserRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendUserRepository.kt
@@ -2,6 +2,13 @@ package net.thechance.trends.repository
 
 import net.thechance.trends.entity.TrendUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.*
 
-interface TrendUserRepository: JpaRepository<TrendUser, UUID>
+interface TrendUserRepository : JpaRepository<TrendUser, UUID> {
+    @Modifying
+    @Query("UPDATE TrendUser u SET u.status = :status WHERE u.userId = :userId")
+    fun updateUserStatus(@Param("userId") userId: UUID, @Param("status") status: TrendUser.Status): Int
+}

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
@@ -11,12 +11,12 @@ import java.util.*
 
 interface TrendsRepository : JpaRepository<Trend, UUID> {
 
-
     @Query(
         """
         SELECT DISTINCT t AS trend, 
                CASE WHEN tl IS NOT NULL THEN true ELSE false END AS isLiked
         FROM Trend t
+        LEFT JOIN FETCH t.owner
         LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :ownerId
         WHERE t.ownerId = :ownerId 
         AND t.isPublished = :isPublished
@@ -46,6 +46,7 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
         SELECT DISTINCT t AS trend, 
                CASE WHEN tl IS NOT NULL THEN true ELSE false END AS isLiked
         FROM Trend t
+        LEFT JOIN FETCH t.owner
         LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
         WHERE t.id = :trendId 
         AND t.isPublished = :isPublished
@@ -59,12 +60,12 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
     )
     fun findByIdAndIsPublishedWithLikeStatus(trendId: UUID, userId: UUID, isPublished: Boolean): TrendWithLikeStatus?
 
-
     @Query(
         """
         SELECT DISTINCT t AS trend, 
                CASE WHEN tl IS NOT NULL THEN true ELSE false END AS isLiked
         FROM Trend t
+        LEFT JOIN FETCH t.owner
         LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :ownerId
         WHERE t.id = :id 
         AND t.ownerId = :ownerId
@@ -82,23 +83,24 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
 
     @Query(
         """
-    SELECT DISTINCT t AS trend, 
-           CASE WHEN tl IS NOT NULL THEN true ELSE false END AS isLiked
-    FROM Trend t
-    LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
-    WHERE t.isPublished = true
-    AND EXISTS (
-        SELECT 1 FROM t.categories tc
-        WHERE tc.id IN (
-            SELECT uc.id FROM TrendUser u
-            JOIN u.categories uc
-            WHERE u.userId = :userId
+        SELECT DISTINCT t AS trend, 
+               CASE WHEN tl IS NOT NULL THEN true ELSE false END AS isLiked
+        FROM Trend t
+        LEFT JOIN FETCH t.owner
+        LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
+        WHERE t.isPublished = true
+        AND EXISTS (
+            SELECT 1 FROM t.categories tc
+            WHERE tc.id IN (
+                SELECT uc.id FROM TrendUser u
+                JOIN u.categories uc
+                WHERE u.userId = :userId
+            )
         )
-    )
-    AND (:trendId IS NULL OR t.createdAt <= (
-        SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
-    ))
-    """,
+        AND (:trendId IS NULL OR t.createdAt <= (
+            SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+        ))
+        """,
         countQuery = """
     SELECT COUNT(DISTINCT t.id)
     FROM Trend t
@@ -122,32 +124,31 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
         pageable: Pageable
     ): Page<TrendWithLikeStatus>
 
-
     @Query(
         """
-    SELECT DISTINCT t AS trend, 
-           true AS isLiked
-    FROM Trend t
-    INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
-    WHERE t.isPublished = true
-    AND (:trendId IS NULL OR t.createdAt <= (
-        SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
-    ))
-    """,
+        SELECT DISTINCT t AS trend, 
+               true AS isLiked
+        FROM Trend t
+        LEFT JOIN FETCH t.owner
+        INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
+        WHERE t.isPublished = true
+        AND (:trendId IS NULL OR t.createdAt <= (
+            SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+        ))
+        """,
         countQuery = """
-    SELECT COUNT(DISTINCT t.id)
-    FROM Trend t
-    INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
-    WHERE t.isPublished = true
-    AND (:trendId IS NULL OR t.createdAt <= (
-        SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
-    ))
-    """
+        SELECT COUNT(DISTINCT t.id)
+        FROM Trend t
+        INNER JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
+        WHERE t.isPublished = true
+        AND (:trendId IS NULL OR t.createdAt <= (
+            SELECT t2.createdAt FROM Trend t2 WHERE t2.id = :trendId
+        ))
+        """
     )
     fun getUserLikedTrends(
         userId: UUID,
         trendId: UUID?,
         pageable: Pageable
     ): Page<TrendWithLikeStatus>
-
 }

--- a/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/repository/TrendsRepository.kt
@@ -89,6 +89,7 @@ interface TrendsRepository : JpaRepository<Trend, UUID> {
         LEFT JOIN FETCH t.owner
         LEFT JOIN TrendLike tl ON tl.trendId = t.id AND tl.userId = :userId
         WHERE t.isPublished = true
+        AND t.owner.status = 'ACTIVE'
         AND EXISTS (
             SELECT 1 FROM t.categories tc
             WHERE tc.id IN (

--- a/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
+++ b/trends/src/main/kotlin/net/thechance/trends/service/TrendUserService.kt
@@ -2,7 +2,6 @@ package net.thechance.trends.service
 
 import net.thechance.trends.api.dto.base.PatchMetadata
 import net.thechance.trends.api.dto.category.toUserSelectedCategories
-import net.thechance.trends.entity.TrendUser
 import net.thechance.trends.exception.InvalidTrendInputException
 import net.thechance.trends.exception.TrendCategoryNotFoundException
 import net.thechance.trends.exception.TrendUserNotFoundException
@@ -12,7 +11,6 @@ import net.thechance.trends.repository.TrendUserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
-import kotlin.jvm.optionals.getOrElse
 import kotlin.jvm.optionals.getOrNull
 
 @Service
@@ -26,7 +24,7 @@ class TrendUserService(
         validateCategoriesNotEmpty(categoryIds)
         validateCategoriesExist(categoryIds)
 
-        val trendUser = getOrCreateUser(userId)
+        val trendUser = getUserOrThrow(userId)
         val categoryProxies = categoryIds.map { categoryId ->
             categoryRepository.getReferenceById(categoryId)
         }.toMutableSet()
@@ -76,9 +74,6 @@ class TrendUserService(
 
     private fun getUserOrThrow(userId: UUID) =
         trendUserRepository.findById(userId).getOrNull() ?: throw TrendUserNotFoundException()
-
-    private fun getOrCreateUser(userId: UUID) =
-        trendUserRepository.findById(userId).getOrElse { TrendUser(userId = userId) }
 
     private fun validateCategoriesNotEmpty(categoryIds: List<UUID>) {
         if (categoryIds.isEmpty()) throw InvalidTrendInputException()


### PR DESCRIPTION
## what is the PR Scope ?
Integrating the user event bus 

## why do we need that ?
To get the user info to send it with the response of trend

## end points with the request and response body:
No new endpoints