### PR TITLE
feature/DKN-192-dukan-creation-event

### DIFF
--- a/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
@@ -7,7 +7,12 @@ data class DukanCreationEvent(
     val id: UUID,
     val ownerId: UUID,
     val name: String,
-    val imageUrl: String?,
-    val lat: Double,
-    val lng: Double
-) : MenaEvent
+    val status: Status = Status.PENDING,
+    val imageUrl: String?
+) : MenaEvent {
+    enum class Status {
+        APPROVED,
+        REJECTED,
+        PENDING,
+    }
+}

--- a/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
@@ -7,12 +7,18 @@ data class DukanCreationEvent(
     val id: UUID,
     val ownerId: UUID,
     val name: String,
+    val imageUrl: String?,
     val status: Status = Status.PENDING,
-    val imageUrl: String?
+    val activationStatus: ActivationStatus? = null
 ) : MenaEvent {
     enum class Status {
         APPROVED,
         REJECTED,
         PENDING,
+    }
+
+    enum class ActivationStatus {
+        ACTIVATED,
+        DEACTIVATED
     }
 }

--- a/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
@@ -9,7 +9,7 @@ data class DukanCreationEvent(
     val name: String,
     val imageUrl: String?,
     val status: Status = Status.PENDING,
-    val activationStatus: ActivationStatus? = null
+    val activationStatus: ActivationStatus?
 ) : MenaEvent {
     enum class Status {
         APPROVED,

--- a/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/DukanCreationEvent.kt
@@ -1,0 +1,13 @@
+package net.thechance.events.dukan
+
+import net.thechance.events.MenaEvent
+import java.util.UUID
+
+data class DukanCreationEvent(
+    val id: UUID,
+    val ownerId: UUID,
+    val name: String,
+    val imageUrl: String?,
+    val lat: Double,
+    val lng: Double
+) : MenaEvent

--- a/events/src/main/kotlin/net/thechance/events/dukan/OrderCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/OrderCreationEvent.kt
@@ -1,0 +1,15 @@
+package net.thechance.events.dukan
+
+import net.thechance.events.MenaEvent
+import java.math.BigDecimal
+import java.util.UUID
+
+data class OrderCreationEvent(
+    val orderId: UUID,
+    val userId: UUID,
+    val dukanId: UUID,
+    val dukanOwnerId: UUID,
+    val totalProducts: Int,
+    val totalPrice: BigDecimal,
+    val address: String
+) : MenaEvent

--- a/events/src/main/kotlin/net/thechance/events/dukan/OrderCreationEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/dukan/OrderCreationEvent.kt
@@ -11,5 +11,5 @@ data class OrderCreationEvent(
     val dukanOwnerId: UUID,
     val totalProducts: Int,
     val totalPrice: BigDecimal,
-    val address: String
+    val deliverToAddress: String
 ) : MenaEvent


### PR DESCRIPTION
## what is the PR Scope ?
- Creating 2 event `DukanCreationEvent` and `OrderCreationEvent`

## why do we need that ?
- So the `wallet` and `chat` team have the data about the dukan creation and order creation from dukan.

## end points with the request and response body:
NAN