### PR TITLE
Feature/idn 216 implement delete account endpoint

### DIFF
--- a/events/src/main/kotlin/net/thechance/events/identity/UserDeletedEvent.kt
+++ b/events/src/main/kotlin/net/thechance/events/identity/UserDeletedEvent.kt
@@ -1,0 +1,8 @@
+package net.thechance.events.identity
+
+import net.thechance.events.MenaEvent
+import java.util.UUID
+
+data class UserDeletedEvent(
+    val id: UUID,
+): MenaEvent

--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
@@ -83,4 +83,13 @@ class ProfileController(
         val response = ChangePasswordResponse("Password changed successfully")
         return ResponseEntity.ok(response)
     }
+
+    @PostMapping("/delete-account")
+    fun deleteAccount(
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<Unit> {
+        userService.deleteUser(userId)
+        return ResponseEntity.ok().build()
+    }
+
 }

--- a/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/controller/profile/ProfileController.kt
@@ -3,6 +3,7 @@ package net.thechance.identity.api.controller.profile
 import jakarta.validation.Valid
 import net.thechance.identity.api.dto.password.ChangePasswordRequest
 import net.thechance.identity.api.dto.password.ChangePasswordResponse
+import net.thechance.identity.api.dto.profile.DeleteAccountResponse
 import net.thechance.identity.api.dto.profile.ProfileResponse
 import net.thechance.identity.api.dto.profile.UpdateImageResponse
 import net.thechance.identity.api.dto.profile.UpdateProfileRequest
@@ -87,9 +88,9 @@ class ProfileController(
     @PostMapping("/delete-account")
     fun deleteAccount(
         @AuthenticationPrincipal userId: UUID
-    ): ResponseEntity<Unit> {
+    ): ResponseEntity<DeleteAccountResponse> {
         userService.deleteUser(userId)
-        return ResponseEntity.ok().build()
+        val response = DeleteAccountResponse("Account deleted successfully")
+        return ResponseEntity.ok(response)
     }
-
 }

--- a/identity/src/main/kotlin/net/thechance/identity/api/dto/profile/DeleteAccountResponse.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/api/dto/profile/DeleteAccountResponse.kt
@@ -1,0 +1,4 @@
+package net.thechance.identity.api.dto.profile
+
+
+data class DeleteAccountResponse(val message: String)

--- a/identity/src/main/kotlin/net/thechance/identity/entity/User.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/entity/User.kt
@@ -14,7 +14,7 @@ data class User(
     @Column(columnDefinition = "uuid", updatable = false, nullable = false)
     val id: UUID = UUID.randomUUID(),
 
-    @Column(name = "phone_number", nullable = false, unique = true)
+    @Column(name = "phone_number", nullable = false)
     val phoneNumber: String,
 
     @Column(name = "password", nullable = false)
@@ -48,7 +48,13 @@ data class User(
 
     @Enumerated(EnumType.STRING)
     @Column(name="status", nullable = false)
-    val status: Status
+    val status: Status,
+
+    @Column(name = "is_deleted", nullable = false)
+    val isDeleted: Boolean = false,
+
+    @Column(name = "deleted_at", nullable = true)
+    val deletedAt: LocalDateTime? = null,
 ) {
     object Gender {
         const val MALE = 1L

--- a/identity/src/main/kotlin/net/thechance/identity/repository/UserRepository.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/repository/UserRepository.kt
@@ -11,9 +11,9 @@ import java.time.LocalDateTime
 import java.util.*
 
 interface UserRepository: JpaRepository<User, UUID> {
-    fun findByPhoneNumber(phoneNumber: String): User?
-    fun existsByUsername(username: String): Boolean
-    fun existsByPhoneNumber(phoneNumber: String): Boolean
+    fun findByPhoneNumberAndIsDeletedFalse(phoneNumber: String): User?
+    fun existsByUsernameAndIsDeletedFalse(username: String): Boolean
+    fun existsByPhoneNumberAndIsDeletedFalse(phoneNumber: String): Boolean
 
     @Query("""
     SELECT u FROM User u
@@ -47,4 +47,5 @@ interface UserRepository: JpaRepository<User, UUID> {
         @Param("status") status: User.Status
     ): Int
 
+    fun existsByIdAndIsDeletedFalse(userId: UUID): Boolean
 }

--- a/identity/src/main/kotlin/net/thechance/identity/repository/UserRepository.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/repository/UserRepository.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 interface UserRepository: JpaRepository<User, UUID> {
     fun findByPhoneNumberAndIsDeletedFalse(phoneNumber: String): User?
-    fun existsByUsernameAndIsDeletedFalse(username: String): Boolean
+    fun existsByUsername(username: String): Boolean
     fun existsByPhoneNumberAndIsDeletedFalse(phoneNumber: String): Boolean
 
     @Query("""

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -32,7 +32,7 @@ class UserService(
 ) {
 
     fun findByPhoneNumber(phoneNumber: String): User {
-        return userRepository.findByPhoneNumber(phoneNumber) ?: throw UserNotFoundException("User not found")
+        return userRepository.findByPhoneNumberAndIsDeletedFalse(phoneNumber) ?: throw UserNotFoundException("User not found")
     }
 
     fun findById(userId: UUID): User {
@@ -98,11 +98,11 @@ class UserService(
     }
 
     fun userExistsByUserName(username: String): Boolean {
-        return userRepository.existsByUsername(username)
+        return userRepository.existsByUsernameAndIsDeletedFalse(username)
     }
 
     fun userExistsByPhoneNumber(phoneNumber: String): Boolean {
-        return userRepository.existsByPhoneNumber(phoneNumber)
+        return userRepository.existsByPhoneNumberAndIsDeletedFalse(phoneNumber)
     }
 
     fun saveUser(user: User): User {
@@ -135,7 +135,13 @@ class UserService(
     }
 
     fun deleteUser(userId: UUID) {
-        if (userExists(userId).not()) throw UserNotFoundException("User with id: $userId not found")
-        userRepository.deleteById(userId)
+        userIsNotDeleted(userId)
+        val user = findById(userId)
+        userRepository.save(user.copy(isDeleted = true, deletedAt = LocalDateTime.now()))
+        eventPublisher.publish(user.toUserUpdatedEvent())
+    }
+
+    fun userIsNotDeleted(userId: UUID){
+        if (userRepository.existsByIdAndIsDeletedFalse(userId).not()) throw UserNotFoundException("User with id: $userId not found")
     }
 }

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -1,6 +1,6 @@
 package net.thechance.identity.service
 
-import jakarta.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 import net.thechance.events.identity.UserDeletedEvent
 import net.thechance.events.identity.UserStatusUpdatedEvent
 import net.thechance.events.publisher.MenaEventPublisher
@@ -135,12 +135,13 @@ class UserService(
         if (status == User.Status.BLOCKED) authenticationService.logout(userId)
     }
 
+    @Transactional
     fun deleteUser(userId: UUID) {
         checkUserIsNotDeleted(userId)
         val user = findById(userId)
         userRepository.save(user.copy(isDeleted = true, deletedAt = LocalDateTime.now()))
-        eventPublisher.publish(UserDeletedEvent(id = user.id))
         authenticationService.logout(user.id)
+        eventPublisher.publish(UserDeletedEvent(id = user.id))
     }
 
     fun checkUserIsNotDeleted(userId: UUID){

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -140,6 +140,7 @@ class UserService(
         val user = findById(userId)
         userRepository.save(user.copy(isDeleted = true, deletedAt = LocalDateTime.now()))
         eventPublisher.publish(UserDeletedEvent(id = user.id))
+        authenticationService.logout(user.id)
     }
 
     fun checkUserIsNotDeleted(userId: UUID){

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -133,4 +133,9 @@ class UserService(
         eventPublisher.publish(UserStatusUpdatedEvent(userId, status.toEventStatus()))
         if (status == User.Status.BLOCKED) authenticationService.logout(userId)
     }
+
+    fun deleteUser(userId: UUID) {
+        if (userExists(userId).not()) throw UserNotFoundException("User with id: $userId not found")
+        userRepository.deleteById(userId)
+    }
 }

--- a/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/UserService.kt
@@ -1,6 +1,7 @@
 package net.thechance.identity.service
 
 import jakarta.transaction.Transactional
+import net.thechance.events.identity.UserDeletedEvent
 import net.thechance.events.identity.UserStatusUpdatedEvent
 import net.thechance.events.publisher.MenaEventPublisher
 import net.thechance.identity.entity.User
@@ -98,7 +99,7 @@ class UserService(
     }
 
     fun userExistsByUserName(username: String): Boolean {
-        return userRepository.existsByUsernameAndIsDeletedFalse(username)
+        return userRepository.existsByUsername(username)
     }
 
     fun userExistsByPhoneNumber(phoneNumber: String): Boolean {
@@ -135,13 +136,13 @@ class UserService(
     }
 
     fun deleteUser(userId: UUID) {
-        userIsNotDeleted(userId)
+        checkUserIsNotDeleted(userId)
         val user = findById(userId)
         userRepository.save(user.copy(isDeleted = true, deletedAt = LocalDateTime.now()))
-        eventPublisher.publish(user.toUserUpdatedEvent())
+        eventPublisher.publish(UserDeletedEvent(id = user.id))
     }
 
-    fun userIsNotDeleted(userId: UUID){
+    fun checkUserIsNotDeleted(userId: UUID){
         if (userRepository.existsByIdAndIsDeletedFalse(userId).not()) throw UserNotFoundException("User with id: $userId not found")
     }
 }

--- a/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
+++ b/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
@@ -35,7 +35,7 @@ class UserServiceTest {
 
     @Test
     fun `findByPhoneNumber() should return User when user exists`() {
-        every { userRepository.findByPhoneNumber(any()) } returns user
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns user
 
         val resultUser = userService.findByPhoneNumber(phoneNumber)
 
@@ -44,18 +44,18 @@ class UserServiceTest {
 
     @Test
     fun `findByPhoneNumber() should throw UserNotFoundException when user not exists`() {
-        every { userRepository.findByPhoneNumber(any()) } returns null
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns null
 
         assertThrows(UserNotFoundException::class.java) { userService.findByPhoneNumber(phoneNumber) }
     }
 
     @Test
     fun `findByPhoneNumber() should call findByPhoneNumber in userRepository one time when called`() {
-        every { userRepository.findByPhoneNumber(any()) } returns user
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns user
 
         userService.findByPhoneNumber(phoneNumber)
 
-        verify(exactly = 1) { userRepository.findByPhoneNumber(any()) }
+        verify(exactly = 1) { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) }
     }
 
     @Test
@@ -112,7 +112,7 @@ class UserServiceTest {
 
     @Test
     fun `updatePasswordByPhoneNumber() should return runs with no exceptions when password updated`() {
-        every { userRepository.findByPhoneNumber(any()) } returns user
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns user
         every { userRepository.save(any()) } returns updatedUser
 
         userService.updatePasswordByPhoneNumber(phoneNumber, PASSWORD)
@@ -120,7 +120,7 @@ class UserServiceTest {
 
     @Test
     fun `updatePasswordByPhoneNumber() should throw PasswordNotUpdatedException when password not updated`() {
-        every { userRepository.findByPhoneNumber(any()) } returns user
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns user
         every { userRepository.save(any()) } returns user
 
         assertThrows(PasswordNotUpdatedException::class.java) {
@@ -131,7 +131,7 @@ class UserServiceTest {
 
     @Test
     fun `updatePasswordByPhoneNumber() should throw UserNotFoundException user not found`() {
-        every { userRepository.findByPhoneNumber(any()) } returns null
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns null
 
         assertThrows(UserNotFoundException::class.java) {
             userService.updatePasswordByPhoneNumber(phoneNumber, PASSWORD)
@@ -140,7 +140,7 @@ class UserServiceTest {
 
     @Test
     fun `updatePasswordByPhoneNumber() should publish event after password updated`() {
-        every { userRepository.findByPhoneNumber(any()) } returns user
+        every { userRepository.findByPhoneNumberAndIsDeletedFalse(any()) } returns user
         every { userRepository.save(any()) } returns updatedUser
 
         userService.updatePasswordByPhoneNumber(phoneNumber, PASSWORD)
@@ -239,7 +239,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByUserName should return true when user exists`() {
-        every { userRepository.existsByUsername(any()) } returns true
+        every { userRepository.existsByUsernameAndIsDeletedFalse(any()) } returns true
 
         val result = userService.userExistsByUserName(user.username)
 
@@ -248,7 +248,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByUserName should return false when user does not exist`() {
-        every { userRepository.existsByUsername(any()) } returns false
+        every { userRepository.existsByUsernameAndIsDeletedFalse(any()) } returns false
 
         val result = userService.userExistsByUserName(user.username)
 
@@ -257,7 +257,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByPhoneNumber should return true when user exists`() {
-        every { userRepository.existsByPhoneNumber(any()) } returns true
+        every { userRepository.existsByPhoneNumberAndIsDeletedFalse(any()) } returns true
 
         val result = userService.userExistsByPhoneNumber(user.phoneNumber)
 
@@ -266,7 +266,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByPhoneNumber should return false when user does not exist`() {
-        every { userRepository.existsByPhoneNumber(any()) } returns false
+        every { userRepository.existsByPhoneNumberAndIsDeletedFalse(any()) } returns false
 
         val result = userService.userExistsByPhoneNumber(user.phoneNumber)
 

--- a/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
+++ b/identity/src/test/kotlin/net/thechance/identity/service/UserServiceTest.kt
@@ -239,7 +239,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByUserName should return true when user exists`() {
-        every { userRepository.existsByUsernameAndIsDeletedFalse(any()) } returns true
+        every { userRepository.existsByUsername(any()) } returns true
 
         val result = userService.userExistsByUserName(user.username)
 
@@ -248,7 +248,7 @@ class UserServiceTest {
 
     @Test
     fun `userExistsByUserName should return false when user does not exist`() {
-        every { userRepository.existsByUsernameAndIsDeletedFalse(any()) } returns false
+        every { userRepository.existsByUsername(any()) } returns false
 
         val result = userService.userExistsByUserName(user.username)
 


### PR DESCRIPTION
## what is the PR Scope ?
implement soft delete for user by add `is_deleted` flag to user table 
default value is false 

and update it to true when delete the user 
there is `deleted_at` column 

## why do we need that ?
for the user to delete his/her account 


## end points with the request and response body:
no body for the request 
only authorization  bearer  token

response with message "account deleted"

