### PR TITLE
fix: add receiverId to ChatResponse

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/api/dto/ChatResponse.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/api/dto/ChatResponse.kt
@@ -8,15 +8,16 @@ data class ChatResponse(
     val name: String,
     val requesterId: UUID,
     val imageUrl: String?,
+    val receiverId: UUID,
 )
-
 
 fun ChatModel.toResponse(): ChatResponse{
     return ChatResponse(
         id = id,
         name = name,
         requesterId = requesterId,
-        imageUrl = imageUrl
+        imageUrl = imageUrl,
+        receiverId = receiverId,
     )
 }
 


### PR DESCRIPTION
## what is the PR Scope ?
add the receiverId to ChatResponse

## why do we need that ?
well, I added it everywhere in the last pr, except in the response object, sadly, so I'm adding it now

## end points with the request and response body:
the new resoponse of chat 

<img width="691" height="299" alt="image" src="https://github.com/user-attachments/assets/4ee60b83-a87e-4a35-ac04-ee62ededcb1e" />
