### PR TITLE
feature/DKN-137-publish-oreder-creation-event

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/order/OrderItemMapper.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/api/mapper/order/OrderItemMapper.kt
@@ -7,7 +7,7 @@ import net.thechance.dukan.entity.Price
 fun OrderItem.toResponse(): OrderItemResponse {
     return OrderItemResponse(
         productId = productId,
-        productName = productImage,
+        productName = productName,
         quantity = quantity,
         price = Price(priceBeforeDiscount, priceAfterDiscount),
         imageUrl = productImage

--- a/dukan/src/main/kotlin/net/thechance/dukan/eventListener/CartEventListener.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/eventListener/CartEventListener.kt
@@ -5,6 +5,7 @@ import net.thechance.dukan.entity.*
 import net.thechance.dukan.repository.*
 import net.thechance.dukan.service.exception.CartNotFoundException
 import net.thechance.dukan.service.exception.DukanNotFoundException
+import net.thechance.events.dukan.OrderCreationEvent
 import net.thechance.events.publisher.MenaEventPublisher
 import net.thechance.events.wallet.TransactionCompletedEvent
 import org.springframework.context.event.EventListener
@@ -28,16 +29,33 @@ class CartEventListener(
     @Async
     fun handle(event: TransactionCompletedEvent) {
         if (event.status != TransactionCompletedEvent.TransactionStatus.SUCCESS) return
+        if (orderRepository.existsByTransactionId(event.transactionId)) {
+            return // event already processed
+        }
 
         val dukan = findDukan(event.receiverId)
         val cart = findActiveCart(event.senderId, dukan.id)
         val user = dukanUserRepository.findById(event.senderId).orElseThrow()
 
         processSoldProducts(cart)
-        createOrderFromCart(cart, user, dukan, event.transactionId)
+        val order = createOrderFromCart(cart, user, dukan, event.transactionId)
         finalizeCartPurchase(cart)
         // TODO: PUBLISH THE ORDER CREATION EVENT
+        val orderCreationEvent = createOrderEvent(order,dukan.ownerId)
+        eventPublisher.publish(orderCreationEvent)
         createNewCart(event.senderId, dukan.id)
+    }
+
+    private fun createOrderEvent(order: Order, ownerId: UUID): OrderCreationEvent {
+        return OrderCreationEvent(
+            orderId = order.id,
+            userId = order.userId,
+            dukanId = order.dukanId,
+            dukanOwnerId = ownerId,
+            totalProducts = order.items.size,
+            totalPrice =order.totalAfterDiscount,
+            deliverToAddress = order.deliveryAddress
+        )
     }
 
     private fun findDukan(ownerId: UUID): Dukan {
@@ -88,11 +106,12 @@ class CartEventListener(
         user: DukanUser,
         dukan: Dukan,
         transactionId: UUID
-    ) {
+    ): Order {
 
         val order = createOrder(cart, transactionId, user, dukan)
 
         orderRepository.save(order)
+        return order
     }
 
     private fun createOrder(

--- a/dukan/src/main/kotlin/net/thechance/dukan/eventListener/CartEventListener.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/eventListener/CartEventListener.kt
@@ -40,10 +40,10 @@ class CartEventListener(
         processSoldProducts(cart)
         val order = createOrderFromCart(cart, user, dukan, event.transactionId)
         finalizeCartPurchase(cart)
-        // TODO: PUBLISH THE ORDER CREATION EVENT
         val orderCreationEvent = createOrderEvent(order,dukan.ownerId)
-        eventPublisher.publish(orderCreationEvent)
-        createNewCart(event.senderId, dukan.id)
+        createNewCart(event.senderId, dukan.id).also {
+            eventPublisher.publish(orderCreationEvent)
+        }
     }
 
     private fun createOrderEvent(order: Order, ownerId: UUID): OrderCreationEvent {

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/CartRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/CartRepository.kt
@@ -18,7 +18,5 @@ interface CartRepository : JpaRepository<Cart, UUID> {
         AND product.isDeleted = false
         """
     )
-    fun findActiveCartByUserIdAndDukanId(userId: UUID, dukanId: UUID): Cart?
-
     fun findByUserIdAndDukanIdAndIsOrderPurchasedFalse(userId: UUID, dukanId: UUID): Cart?
 }

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/OrderRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/OrderRepository.kt
@@ -4,4 +4,6 @@ import net.thechance.dukan.entity.Order
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
-interface OrderRepository : JpaRepository<Order, UUID>
+interface OrderRepository : JpaRepository<Order, UUID>{
+    fun existsByTransactionId(transactionId:UUID):Boolean
+}

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
@@ -81,7 +81,7 @@ class CartService(
 
     @Transactional(readOnly = true)
     fun getCartOrThrow(userId: UUID, dukanId: UUID): Cart {
-        return cartRepository.findActiveCartByUserIdAndDukanId(userId, dukanId)
+        return cartRepository.findByUserIdAndDukanIdAndIsOrderPurchasedFalse(userId, dukanId)
             ?: throw CartNotFoundException()
     }
 
@@ -153,7 +153,7 @@ class CartService(
     }
 
     private fun getCartByUserAndDukan(userId: UUID, dukanId: UUID): Cart? {
-        return cartRepository.findActiveCartByUserIdAndDukanId(userId, dukanId)
+        return cartRepository.findByUserIdAndDukanIdAndIsOrderPurchasedFalse(userId, dukanId)
     }
 
     private fun getOrCreateActiveCart(userId: UUID, dukanId: UUID): Cart {

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
@@ -108,12 +108,14 @@ class CartService(
 
         val transactionId = UUID.randomUUID()
 
-        createTransactionEvent(transactionId, cart, dukan)
+        val initEvent = createTransactionEvent(transactionId, cart, dukan)
 
         return CartCheckoutPreview(
             transactionId = transactionId,
             totalAmount = cart.price.final.toDouble()
-        )
+        ).also {
+            eventPublisher.publish(initEvent)
+        }
     }
 
     private fun updateUserLocation(
@@ -140,16 +142,14 @@ class CartService(
         transactionId: UUID,
         cart: Cart,
         dukan: Dukan
-    ) {
-        val transactionEvent = InitiateTransactionEvent(
+    ) :InitiateTransactionEvent{
+        return InitiateTransactionEvent(
             transactionId = transactionId,
             type = InitiateTransactionEvent.TransactionType.ONLINE_PURCHASE,
             senderId = cart.userId,
             receiverId = dukan.ownerId,
             amount = cart.price.final.toDouble()
         )
-
-        eventPublisher.publish(transactionEvent)
     }
 
     private fun getCartByUserAndDukan(userId: UUID, dukanId: UUID): Cart? {

--- a/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/service/CartService.kt
@@ -157,7 +157,7 @@ class CartService(
     }
 
     private fun getOrCreateActiveCart(userId: UUID, dukanId: UUID): Cart {
-        return cartRepository.findActiveCartByUserIdAndDukanId(userId, dukanId)
+        return cartRepository.findByUserIdAndDukanIdAndIsOrderPurchasedFalse(userId, dukanId)
             ?: createCart(userId, dukanId)
     }
 


### PR DESCRIPTION
## what is the PR Scope ?
order creation in dukan feature

## why do we need that ?
After a cart is checked out and the wallet service confirms the transaction:
	•	we must freeze the cart into an immutable order snapshot
	•	update sold products
	•	finalize the cart
	•	create a new cart for the user
	•	then publish OrderCreationEvent
so the Chat team (and others) can react to newly created orders.

## end points with the request and response body:
No new endpoints were added.

Order creation is triggered automatically after:
	1.	POST /dukan/cart/checkout
	2.	Wallet publishes TransactionCompletedEvent
	3.	Dukan listener creates an order and publishes OrderCreationEvent