### PR TITLE
fix updating dukan , remove redundant GeneratedValue from dukan id

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/entity/Dukan.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/entity/Dukan.kt
@@ -9,7 +9,6 @@ import java.util.Collections.emptySet
 @Entity
 data class Dukan(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     val id: UUID = UUID.randomUUID(),
     @Column(name = "owner_id", nullable = false, unique = true)
     val ownerId: UUID,


### PR DESCRIPTION
## what is the PR Scope ?
Fix a problem in updating dukan , remove generated value from dukan entity , 
## why do we need that ?
we need this cause when update dukan its try to insert new one with same owner id but with different id instead of actually updating the exist one which caused a problem in creating dukan processing and uploading image 

## end points with the request and response body:
