### PR TITLE
Fix: Update SHA256 certificate fingerprint in assetlinks.json

### DIFF
--- a/app/src/main/resources/static/.well-known/assetlinks.json
+++ b/app/src/main/resources/static/.well-known/assetlinks.json
@@ -7,7 +7,7 @@
       "namespace": "android_app",
       "package_name": "net.thechance.mena.dev",
       "sha256_cert_fingerprints": [
-        "C6:53:A2:9B:A1:38:AB:09:4C:E2:0C:07:0E:CC:F7:B3:0F:40:70:BA:74:63:46:04:37:EF:44:CE:B0:B8:B0:17"
+        "FF:38:32:68:EA:5A:82:7F:20:85:41:D8:6C:9B:9D:01:F7:6E:CA:30:8F:86:AF:B5:1F:4C:11:62:B5:EE:DE:D4"
       ]
     }
   }


### PR DESCRIPTION
## what is the PR Scope ?

This PR replace old debug certificate with a signed release certificate.

## why do we need that ?

We need it  to open deep link automatically without any manual verification.