### PR TITLE
increase short-term attempts limit for OTP endpoints to 2

### DIFF
--- a/identity/src/main/kotlin/net/thechance/identity/service/PhoneNumberRateLimitService.kt
+++ b/identity/src/main/kotlin/net/thechance/identity/service/PhoneNumberRateLimitService.kt
@@ -14,8 +14,8 @@ class PhoneNumberRateLimitService(
         val pageable = PageRequest.of(0, MAX_RETRIES_PER_WINDOW)
         val latestOtpLog = otpLogRepository.findByPhoneNumberOrderByCreatedAtDesc(phoneNumber, pageable)
         if (latestOtpLog.isNotEmpty()) {
-            val isLastRequestIsFrequent =
-                latestOtpLog.first().createdAt > Instant.now().minusSeconds(MIN_OTP_RESEND_GAP_SECONDS)
+            val cutoff = Instant.now().minusSeconds(MIN_OTP_RESEND_GAP_SECONDS)
+            val isLastRequestIsFrequent = latestOtpLog.take(2).all { it.createdAt > cutoff }
             val ifWindowLimitExceeded =
                 latestOtpLog.size == MAX_RETRIES_PER_WINDOW && latestOtpLog.last().createdAt > Instant.now()
                     .minusSeconds(

--- a/identity/src/main/resources/identity-rate-limit.properties
+++ b/identity/src/main/resources/identity-rate-limit.properties
@@ -8,7 +8,7 @@ identity-rate-limit.endpoints[/identity/authentication/refresh].short-term-windo
 identity-rate-limit.endpoints[/identity/authentication/refresh].long-term-attempts-limit=10
 identity-rate-limit.endpoints[/identity/authentication/refresh].long-term-window-seconds=3600
 identity-rate-limit.endpoints[/identity/authentication/refresh].block-duration-seconds=900
-identity-rate-limit.endpoints[/identity/authentication/request-reset-password-otp].short-term-attempts-limit=1
+identity-rate-limit.endpoints[/identity/authentication/request-reset-password-otp].short-term-attempts-limit=2
 identity-rate-limit.endpoints[/identity/authentication/request-reset-password-otp].short-term-window-seconds=60
 identity-rate-limit.endpoints[/identity/authentication/request-reset-password-otp].long-term-attempts-limit=5
 identity-rate-limit.endpoints[/identity/authentication/request-reset-password-otp].long-term-window-seconds=600
@@ -23,7 +23,7 @@ identity-rate-limit.endpoints[/identity/authentication/reset-password].short-ter
 identity-rate-limit.endpoints[/identity/authentication/reset-password].long-term-attempts-limit=5
 identity-rate-limit.endpoints[/identity/authentication/reset-password].long-term-window-seconds=120
 identity-rate-limit.endpoints[/identity/authentication/reset-password].block-duration-seconds=300
-identity-rate-limit.endpoints[/identity/authentication/register/request-otp].short-term-attempts-limit=1
+identity-rate-limit.endpoints[/identity/authentication/register/request-otp].short-term-attempts-limit=2
 identity-rate-limit.endpoints[/identity/authentication/register/request-otp].short-term-window-seconds=60
 identity-rate-limit.endpoints[/identity/authentication/register/request-otp].long-term-attempts-limit=5
 identity-rate-limit.endpoints[/identity/authentication/register/request-otp].long-term-window-seconds=600


### PR DESCRIPTION
## what is the PR Scope ?
increase otp request to 2 per ip and phone number instead of one 

## why do we need that ?
for better user experience in mobile 

## end points with the request and response body:
