### PR TITLE
fix: duplicated products returned after purchase

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/CartRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/CartRepository.kt
@@ -12,7 +12,7 @@ interface CartRepository : JpaRepository<Cart, UUID> {
         FROM Cart cart
         JOIN FETCH cart.items item
         JOIN FETCH item.product product
-        WHERE (cart.isOrderPurchased = false OR cart.isOrderPurchased IS NOT NULL)
+        WHERE (cart.isOrderPurchased = false OR cart.isOrderPurchased IS NULL)
         AND cart.userId = :userId 
         AND cart.dukanId = :dukanId
         AND product.isDeleted = false

--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanProductRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanProductRepository.kt
@@ -45,7 +45,7 @@ interface DukanProductRepository : JpaRepository<DukanProduct, UUID> {
 
     @Query(
         """
-        SELECT new net.thechance.dukan.service.model.DukanProductWithFavoriteAndQuantity(
+        SELECT DISTINCT new net.thechance.dukan.service.model.DukanProductWithFavoriteAndQuantity(
             product,
             CASE WHEN favorite.id.productId IS NOT NULL THEN true ELSE false END,
             COALESCE(cartItem.quantity, 0)
@@ -56,11 +56,13 @@ interface DukanProductRepository : JpaRepository<DukanProduct, UUID> {
         LEFT JOIN FavoriteProduct favorite
             ON favorite.id.productId = product.id AND favorite.id.userId = :userId
         LEFT JOIN Cart cart
-            ON cart.userId = :userId AND cart.dukanId = dukan.id
+            ON cart.userId = :userId
+            AND cart.dukanId = dukan.id
+            AND cart.isOrderPurchased = false
         LEFT JOIN cart.items cartItem
             ON cartItem.product.id = product.id
         WHERE shelf.id = :shelfId AND (product.isDeleted = false)
-        """
+    """
     )
     fun findProductsWithFavoriteAndQuantityByShelf(
         @Param("userId") userId: UUID,


### PR DESCRIPTION
## what is the PR Scope ?
Fixes duplicated products after the purchase operation

## why do we need that ?
To not return duplicated products 

## end points with the request and response body:
NA/AN