### PR TITLE
fix: chats images not having base url

### DIFF
--- a/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ChatService.kt
@@ -8,6 +8,7 @@ import net.thechance.chat.repository.MessageRepository
 import net.thechance.chat.service.exception.InvalidTimeFormatException
 import net.thechance.chat.service.exception.NotFoundException
 import net.thechance.chat.service.model.*
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -25,7 +26,11 @@ class ChatService(
     private val contactUserService: ContactUserService,
     private val attachmentStorageService: AttachmentStorageService,
     private val contactService: ContactService,
+    @Value("\${storage.mena.cdn-endpoint}") cdnEndpoint: String,
+    @Value("\${identity.resources.profile-image-directory}") profileImageDirectory: String,
 ) {
+
+    private val imagesBaseUrl: String = "$cdnEndpoint$profileImageDirectory"
 
     @Transactional
     fun getChatByUserIds(userId: UUID, receiverId: UUID): ChatModel {
@@ -35,7 +40,7 @@ class ChatService(
         val contact = contactService.getContactByOwnerIdAndContactUserId(userId, otherUser.id)
 
         val chatName = getChatName(contact, otherUser)
-        val imageUrl = otherUser.imageUrl.orEmpty()
+        val imageUrl = otherUser.imageUrl?.let { "$imagesBaseUrl/$it" }
 
         val chat = findOrCreateChat(
             usersId = usersId,
@@ -179,7 +184,7 @@ class ChatService(
             val otherUser = chat.users.firstOrNull { it.id != userId }
             val contact = otherUser?.let { contactService.getContactByOwnerIdAndContactUserId(userId, it.id) }
             val chatName = getChatName(contact, otherUser)
-            val imageUrl = otherUser?.imageUrl.orEmpty()
+            val imageUrl = otherUser?.imageUrl?.let { "$imagesBaseUrl/$it" }
 
             chat.toSummary(
                 userId = userId,
@@ -200,7 +205,7 @@ class ChatService(
         val unreadCount = chatRepository.findUnreadCountsForChats(listOf(chatId)).firstOrNull()?.unreadCount ?: 0
         val contact = otherUser?.let { contactService.getContactByOwnerIdAndContactUserId(userId, it.id) }
         val chatName = getChatName(contact, otherUser)
-        val imageUrl = otherUser?.imageUrl.orEmpty()
+        val imageUrl = otherUser?.imageUrl?.let { "$imagesBaseUrl/$it" }
         return chat.toSummary(
             userId = userId,
             chatName = chatName,
@@ -219,7 +224,7 @@ class ChatService(
         }
         return ChatModel(
             name = getChatName(contact, otherUser),
-            imageUrl = otherUser.imageUrl,
+            imageUrl = otherUser.imageUrl?.let { "$imagesBaseUrl/$it" },
             requesterId = userId,
             id = chatId,
             receiverId = otherUser.id,

--- a/chat/src/main/kotlin/net/thechance/chat/service/ContactService.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/ContactService.kt
@@ -41,7 +41,7 @@ class ContactService(
     fun parseContacts(contacts: List<Contact>, ownerId: UUID): List<Contact> {
         if (contacts.isEmpty()) return emptyList()
         val ownerPhoneNumber = contactUserService.getPhoneNumberByUserId(ownerId) ?: return emptyList()
-        val ownerRegion = phoneNumberParses.parse(ownerPhoneNumber, "").countryCode
+        val ownerRegion = phoneNumberParses.parse(ownerPhoneNumber, "").regionCode
         return contacts
             .mapNotNull { contact ->
                 try {

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/ChatModel.kt
@@ -11,7 +11,7 @@ data class ChatModel(
     val id: UUID,
 )
 
-fun Chat.toModel(chatName: String, imageUrl:String, requesterId: UUID): ChatModel{
+fun Chat.toModel(chatName: String, imageUrl:String?, requesterId: UUID): ChatModel{
     return ChatModel(
         name = chatName,
         imageUrl = imageUrl,

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/ChatSummary.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/ChatSummary.kt
@@ -13,7 +13,7 @@ data class ChatSummary(
     val unReadMessagesCount: Int
 )
 
-fun Chat.toSummary(chatName: String, imageUrl:String, lastMessage: Message?, unreadCount: Int): ChatSummary {
+fun Chat.toSummary(chatName: String, imageUrl: String?, lastMessage: Message?, unreadCount: Int): ChatSummary {
     return ChatSummary(
         id = id,
         name = chatName,

--- a/chat/src/main/kotlin/net/thechance/chat/service/model/ChatSummary.kt
+++ b/chat/src/main/kotlin/net/thechance/chat/service/model/ChatSummary.kt
@@ -18,7 +18,7 @@ data class ChatSummary(
         val isMine: Boolean
     )
 }
-fun Chat.toSummary(userId: UUID, chatName: String, imageUrl:String, lastMessage: Message?, unreadCount: Int): ChatSummary {
+fun Chat.toSummary(userId: UUID, chatName: String, imageUrl:String?, lastMessage: Message?, unreadCount: Int): ChatSummary {
     return ChatSummary(
         id = id,
         name = chatName,


### PR DESCRIPTION
## what is the PR Scope ?
the image url for chats

## why do we need that ?
so the images will appear correctly

## end points with the request and response body:
the chat response now have the base url, look the image below
<img width="701" height="611" alt="image" src="https://github.com/user-attachments/assets/0c13cc83-4678-401f-9746-e2501a4b7a6b" />
