### PR TITLE
fix: duplicated dukans in Editor Picks

### DIFF
--- a/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
+++ b/dukan/src/main/kotlin/net/thechance/dukan/repository/DukanRepository.kt
@@ -207,12 +207,24 @@ interface DukanRepository : JpaRepository<Dukan, UUID> {
     )
     FROM Dukan dukan
     LEFT JOIN FavoriteDukan favorite 
-        ON favorite.id.dukanId = dukan.id AND favorite.id.userId = :userId
-    JOIN dukan.categories category
-    WHERE category.id IN :categoryIds
-      AND dukan.status = net.thechance.dukan.entity.Dukan.Status.APPROVED
-      AND dukan.activationStatus = net.thechance.dukan.entity.Dukan.ActivationStatus.ACTIVATED
-    ORDER BY dukan.createdAt DESC
+        ON favorite.id.dukanId = dukan.id 
+        AND favorite.id.userId = :userId
+    WHERE dukan.id IN (
+        SELECT DISTINCT d.id 
+        FROM Dukan d
+        JOIN d.categories c
+        WHERE c.id IN :categoryIds
+            AND d.status = net.thechance.dukan.entity.Dukan.Status.APPROVED
+            AND d.activationStatus = net.thechance.dukan.entity.Dukan.ActivationStatus.ACTIVATED
+    )
+    ORDER BY (
+        SELECT COUNT(c2.id)
+        FROM Dukan d2
+        JOIN d2.categories c2
+        WHERE d2.id = dukan.id 
+            AND c2.id IN :categoryIds
+    ) DESC,
+    dukan.createdAt DESC
     """
     )
     fun findRecommendedDukansForUser(


### PR DESCRIPTION
## what is the PR Scope ?
Fix editor picks returns duplicated dukans

## why do we need that ?
To prevent duplicated entries for relative dukans

## end points with the request and response body:
