### PR TITLE
Fix/wlt 203 timezone handling inconsistencies

### DIFF
--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/TransactionController.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/TransactionController.kt
@@ -39,17 +39,16 @@ class TransactionController(
         @RequestParam(required = false) status: Transaction.Status?,
         @RequestParam(name = "from", required = false) startDate: LocalDate?,
         @RequestParam(name = "to", required = false) endDate: LocalDate?,
-        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
+        @RequestHeader(value = "Accept-Timezone", defaultValue = "UTC") timezone: ZoneId,
         pageable: Pageable
     ): ResponseEntity<PageResponse<TransactionResponse>> {
-        val clientZone = ZoneId.of(timezone)
         val response = transactionService.getFilteredTransactions(
             transactionFilterParams = TransactionFilterParams(
                 types = types,
                 status = status,
-                startDateTime = startDate?.atStartOfDay()?.toServerZone(clientZone),
-                endDateTime = endDate?.atEndOfDay()?.toServerZone(clientZone),
-                ),
+                startDateTime = startDate?.atStartOfDay()?.toServerZone(timezone),
+                endDateTime = endDate?.atEndOfDay()?.toServerZone(timezone),
+            ),
             pageable = PageRequest.of(
                 pageable.pageNumber,
                 pageable.pageSize,
@@ -64,11 +63,10 @@ class TransactionController(
     @GetMapping("/first-date")
     fun getUserFirstTransactionDate(
         @AuthenticationPrincipal userId: UUID,
-        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
-        ): ResponseEntity<FirstTransactionDateResponse> {
-        val clientZone = ZoneId.of(timezone)
+        @RequestHeader(value = "Accept-Timezone", defaultValue = "UTC") timezone: ZoneId,
+    ): ResponseEntity<FirstTransactionDateResponse> {
         val response = transactionService.getUserFirstTransactionDate(currentUserId = userId)
-            .toFirstTransactionDateResponse(clientZone)
+            .toFirstTransactionDateResponse(timezone)
 
         return ResponseEntity.ok(response)
     }
@@ -92,11 +90,12 @@ class TransactionController(
         @RequestParam(name = "type", required = false) types: List<UserTransactionType>?,
         @RequestParam(name = "from", required = false) startDate: LocalDate?,
         @RequestParam(name = "to", required = false) endDate: LocalDate?,
-        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
+        @RequestHeader(value = "Accept-Timezone", defaultValue = "UTC") timezone: ZoneId,
     ) {
         val buffer = ByteArrayOutputStream()
 
-        val metadata = statementPdfWriter.writePdfToStream(userId, types, startDate, endDate, timezone, outputStream = buffer)
+        val metadata =
+            statementPdfWriter.writePdfToStream(userId, types, startDate, endDate, timezone, outputStream = buffer)
 
         response.contentType = "application/pdf"
         response.setHeader(

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/TransactionController.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/TransactionController.kt
@@ -10,6 +10,8 @@ import net.thechance.wallet.entity.Transaction
 import net.thechance.wallet.service.TransactionService
 import net.thechance.wallet.service.model.input.TransactionFilterParams
 import net.thechance.wallet.service.model.input.UserTransactionType
+import net.thechance.wallet.service.utils.atEndOfDay
+import net.thechance.wallet.service.utils.toServerZone
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -17,7 +19,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.io.ByteArrayOutputStream
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.*
 
 
@@ -33,13 +37,19 @@ class TransactionController(
         @AuthenticationPrincipal userId: UUID,
         @RequestParam(name = "type", required = false) types: List<UserTransactionType>?,
         @RequestParam(required = false) status: Transaction.Status?,
-        @RequestParam(name = "from", required = false) startDateTime: LocalDateTime?,
-        @RequestParam(name = "to", required = false) endDateTime: LocalDateTime?,
+        @RequestParam(name = "from", required = false) startDate: LocalDate?,
+        @RequestParam(name = "to", required = false) endDate: LocalDate?,
+        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
         pageable: Pageable
     ): ResponseEntity<PageResponse<TransactionResponse>> {
-
+        val clientZone = ZoneId.of(timezone)
         val response = transactionService.getFilteredTransactions(
-            transactionFilterParams = TransactionFilterParams(types, status, startDateTime, endDateTime),
+            transactionFilterParams = TransactionFilterParams(
+                types = types,
+                status = status,
+                startDateTime = startDate?.atStartOfDay()?.toServerZone(clientZone),
+                endDateTime = endDate?.atEndOfDay()?.toServerZone(clientZone),
+                ),
             pageable = PageRequest.of(
                 pageable.pageNumber,
                 pageable.pageSize,
@@ -54,9 +64,11 @@ class TransactionController(
     @GetMapping("/first-date")
     fun getUserFirstTransactionDate(
         @AuthenticationPrincipal userId: UUID,
-    ): ResponseEntity<FirstTransactionDateResponse> {
+        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
+        ): ResponseEntity<FirstTransactionDateResponse> {
+        val clientZone = ZoneId.of(timezone)
         val response = transactionService.getUserFirstTransactionDate(currentUserId = userId)
-            .toFirstTransactionDateResponse()
+            .toFirstTransactionDateResponse(clientZone)
 
         return ResponseEntity.ok(response)
     }
@@ -78,12 +90,13 @@ class TransactionController(
         response: HttpServletResponse,
         @AuthenticationPrincipal userId: UUID,
         @RequestParam(name = "type", required = false) types: List<UserTransactionType>?,
-        @RequestParam(name = "from", required = false) startDateTime: LocalDateTime?,
-        @RequestParam(name = "to", required = false) endDateTime: LocalDateTime?,
+        @RequestParam(name = "from", required = false) startDate: LocalDate?,
+        @RequestParam(name = "to", required = false) endDate: LocalDate?,
+        @RequestParam(name = "timezone", defaultValue = "UTC") timezone: String,
     ) {
         val buffer = ByteArrayOutputStream()
 
-        val metadata = statementPdfWriter.writePdfToStream(userId, types, startDateTime, endDateTime, outputStream = buffer)
+        val metadata = statementPdfWriter.writePdfToStream(userId, types, startDate, endDate, timezone, outputStream = buffer)
 
         response.contentType = "application/pdf"
         response.setHeader(

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementHtmlGenerator.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementHtmlGenerator.kt
@@ -2,6 +2,7 @@ package net.thechance.wallet.api.controller.util
 
 import net.thechance.wallet.entity.Transaction
 import net.thechance.wallet.service.model.output.StatementData
+import net.thechance.wallet.service.utils.toClientZone
 import org.springframework.data.domain.Page
 import org.springframework.stereotype.Component
 import org.thymeleaf.TemplateEngine
@@ -9,6 +10,7 @@ import org.thymeleaf.context.Context
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 
@@ -19,10 +21,11 @@ class StatementHtmlGenerator(
 
     fun generateForPage(
         statementData: StatementData,
+        timezone: ZoneId,
         transactionsPage: Page<Transaction>,
     ): String {
         val formattedTransactions = transactionsPage.content.map {
-            formatTransaction(it, statementData.userId)
+            formatTransaction(it, statementData.userId, timezone)
         }
 
         val templateData = mapOf(
@@ -40,11 +43,11 @@ class StatementHtmlGenerator(
         return templateEngine.process("statement", context)
     }
 
-    private fun formatTransaction(transaction: Transaction, currentUserId: UUID): Map<String, Any> {
+    private fun formatTransaction(transaction: Transaction, currentUserId: UUID, timezone: ZoneId): Map<String, Any> {
         return mapOf(
             "id" to "TX-" + transaction.id.toString().substring(0, 6),
-            "date" to transaction.createdAt.formatRowItemDate(),
-            "time" to transaction.createdAt.formatRowItemTime(),
+            "date" to transaction.createdAt.formatRowItemDate(timezone),
+            "time" to transaction.createdAt.formatRowItemTime(timezone),
             "typeHeader" to getTypeHeader(transaction, currentUserId),
             "counterParty" to getCounterParty(transaction, currentUserId),
             "amount" to formatTransactionAmount(currentUserId, transaction),
@@ -98,9 +101,12 @@ class StatementHtmlGenerator(
         }
     }
 
-    private fun LocalDateTime.formatRowItemDate(): String =
-        this.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+    private fun LocalDateTime.formatRowItemDate(timezone: ZoneId): String =
+        this.toClientZone(timezone)
+            .format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
 
-    private fun LocalDateTime.formatRowItemTime(): String =
-        this.format(DateTimeFormatter.ofPattern("HH:mm a"))
+    private fun LocalDateTime.formatRowItemTime(timezone: ZoneId): String =
+        this.toClientZone(timezone)
+            .format(DateTimeFormatter.ofPattern("hh:mm a"))
+
 }

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPageEventHandler.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPageEventHandler.kt
@@ -12,14 +12,17 @@ import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.Document
 import com.itextpdf.svg.converter.SvgConverter
 import net.thechance.wallet.service.model.output.StatementData
+import net.thechance.wallet.service.utils.toClientZone
 import org.springframework.core.io.ResourceLoader
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 
 class StatementPageEventHandler(
     private val resourceLoader: ResourceLoader,
-    private val statementData: StatementData
+    private val statementData: StatementData,
+    private val timezone: ZoneId,
 ) : AbstractPdfDocumentEventHandler() {
     private val poppinsRegular by lazy { getPoppinsRegularFont() }
     private val poppinsSemiBold by lazy { getPoppinsSemiBoldFont() }
@@ -140,5 +143,5 @@ class StatementPageEventHandler(
     }
 
     private fun LocalDateTime.formatHeaderDate(): String =
-        this.format(DateTimeFormatter.ofPattern("MMM dd yyyy"))
+        this.toClientZone(timezone).format(DateTimeFormatter.ofPattern("MMM dd yyyy"))
 }

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPdfWriter.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPdfWriter.kt
@@ -13,11 +13,15 @@ import com.itextpdf.layout.properties.AreaBreakType
 import net.thechance.wallet.service.StatementService
 import net.thechance.wallet.service.model.input.UserTransactionType
 import net.thechance.wallet.service.model.output.StatementData
+import net.thechance.wallet.service.utils.atEndOfDay
+import net.thechance.wallet.service.utils.toClientZone
+import net.thechance.wallet.service.utils.toServerZone
 import org.springframework.core.io.ResourceLoader
 import org.springframework.stereotype.Component
 import java.io.OutputStream
 import java.math.BigDecimal
-import java.time.LocalDateTime
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.*
 
 @Component
@@ -29,21 +33,28 @@ class StatementPdfWriter(
     fun writePdfToStream(
         userId: UUID,
         types: List<UserTransactionType>?,
-        startDateTime: LocalDateTime?,
-        endDateTime: LocalDateTime?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        timezone: String,
         outputStream: OutputStream
     ): StatementMetadata {
-        val statementData = statementService.getStatementData(userId, types, startDateTime, endDateTime)
+        val clientZone = ZoneId.of(timezone)
+        val statementData = statementService.getStatementData(
+            userId = userId,
+            types = types,
+            startDateTime = startDate?.atStartOfDay()?.toServerZone(clientZone),
+            endDateTime = endDate?.atEndOfDay()?.toServerZone(clientZone),
+        )
 
         val writer = PdfWriter(outputStream)
         val pdf = PdfDocument(writer)
         val document = Document(pdf)
         val converterProperties = setupConverterProperties()
 
-        pdf.addEventHandler(PdfDocumentEvent.END_PAGE, StatementPageEventHandler(resourceLoader, statementData))
+        pdf.addEventHandler(PdfDocumentEvent.END_PAGE, StatementPageEventHandler(resourceLoader, statementData, clientZone))
         document.setMargins(100f, 32f, 60f, 32f)
 
-        val metadata = writePages(statementData, document, converterProperties)
+        val metadata = writePages(statementData, clientZone, document, converterProperties)
 
         pdf.close()
         outputStream.flush()
@@ -53,6 +64,7 @@ class StatementPdfWriter(
 
     private fun writePages(
         statementData: StatementData,
+        timezone: ZoneId,
         pdf: Document,
         converterProperties: ConverterProperties
     ): StatementMetadata {
@@ -63,14 +75,14 @@ class StatementPdfWriter(
 
         do {
             val page = statementService.getTransactionsPage(
-                statementData.userId,
-                statementData.startDateTime,
-                statementData.endDateTime,
-                statementData.types,
-                pageNum
+                userId = statementData.userId,
+                startDateTime = statementData.startDateTime,
+                endDateTime = statementData.endDateTime,
+                types = statementData.types,
+                pageNum = pageNum
             )
 
-            val htmlContent = statementHtmlGenerator.generateForPage(statementData, page)
+            val htmlContent = statementHtmlGenerator.generateForPage(statementData, timezone, page)
             val elements = HtmlConverter.convertToElements(htmlContent, converterProperties)
             elements.forEach { element ->
                 pdf.add(element as IBlockElement)
@@ -88,8 +100,8 @@ class StatementPdfWriter(
         } while (pageNum < totalPages)
 
         return StatementMetadata(
-            startDate = statementData.startDateTime.toLocalDate(),
-            endDate = statementData.endDateTime.toLocalDate(),
+            startDate = statementData.startDateTime.toClientZone(timezone).toLocalDate(),
+            endDate = statementData.endDateTime.toClientZone(timezone).toLocalDate(),
             totalInflows = totalInflows,
             totalOutflows = totalOutflows
         )

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPdfWriter.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/controller/util/StatementPdfWriter.kt
@@ -35,15 +35,14 @@ class StatementPdfWriter(
         types: List<UserTransactionType>?,
         startDate: LocalDate?,
         endDate: LocalDate?,
-        timezone: String,
+        timezone: ZoneId,
         outputStream: OutputStream
     ): StatementMetadata {
-        val clientZone = ZoneId.of(timezone)
         val statementData = statementService.getStatementData(
             userId = userId,
             types = types,
-            startDateTime = startDate?.atStartOfDay()?.toServerZone(clientZone),
-            endDateTime = endDate?.atEndOfDay()?.toServerZone(clientZone),
+            startDateTime = startDate?.atStartOfDay()?.toServerZone(timezone),
+            endDateTime = endDate?.atEndOfDay()?.toServerZone(timezone),
         )
 
         val writer = PdfWriter(outputStream)
@@ -51,10 +50,10 @@ class StatementPdfWriter(
         val document = Document(pdf)
         val converterProperties = setupConverterProperties()
 
-        pdf.addEventHandler(PdfDocumentEvent.END_PAGE, StatementPageEventHandler(resourceLoader, statementData, clientZone))
+        pdf.addEventHandler(PdfDocumentEvent.END_PAGE, StatementPageEventHandler(resourceLoader, statementData, timezone))
         document.setMargins(100f, 32f, 60f, 32f)
 
-        val metadata = writePages(statementData, clientZone, document, converterProperties)
+        val metadata = writePages(statementData, timezone, document, converterProperties)
 
         pdf.close()
         outputStream.flush()

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/dto/balance/AdminDepositRequest.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/dto/balance/AdminDepositRequest.kt
@@ -1,8 +1,11 @@
 package net.thechance.wallet.api.dto.balance
 
+import jakarta.validation.constraints.DecimalMin
 import java.math.BigDecimal
 
 data class AdminDepositRequest(
     val phoneNumber : String,
+
+    @field:DecimalMin(value = "0.0", inclusive = false, message = "Amount must be greater than zero")
     val amount: BigDecimal,
 )

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/dto/transaction/FirstTransactionDateResponse.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/dto/transaction/FirstTransactionDateResponse.kt
@@ -1,12 +1,14 @@
 package net.thechance.wallet.api.dto.transaction
 
+import net.thechance.wallet.service.utils.toClientZone
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 data class FirstTransactionDateResponse(
     val firstTransactionDate: LocalDate?,
 )
 
-fun LocalDateTime?.toFirstTransactionDateResponse(): FirstTransactionDateResponse {
-    return FirstTransactionDateResponse(firstTransactionDate = this?.toLocalDate())
+fun LocalDateTime?.toFirstTransactionDateResponse(timezone: ZoneId): FirstTransactionDateResponse {
+    return FirstTransactionDateResponse(this?.toClientZone(timezone)?.toLocalDate())
 }

--- a/wallet/src/main/kotlin/net/thechance/wallet/api/dto/transaction/InitiateTransactionRequest.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/api/dto/transaction/InitiateTransactionRequest.kt
@@ -1,11 +1,14 @@
 package net.thechance.wallet.api.dto.transaction
 
+import jakarta.validation.constraints.DecimalMin
 import net.thechance.wallet.entity.Transaction
 import net.thechance.wallet.service.model.input.InitiateTransactionParams
 import java.util.*
 
 data class InitiateTransactionRequest(
     val receiverId: UUID,
+
+    @field:DecimalMin(value = "0.0", inclusive = false, message = "Amount must be greater than zero")
     val amount: Double,
 )
 

--- a/wallet/src/main/kotlin/net/thechance/wallet/service/utils/DateExtensions.kt
+++ b/wallet/src/main/kotlin/net/thechance/wallet/service/utils/DateExtensions.kt
@@ -2,7 +2,24 @@ package net.thechance.wallet.service.utils
 
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 fun LocalDateTime?.orNow(): LocalDateTime = this ?: LocalDateTime.now()
 
-fun LocalDate?.atEndOfDay() = this?.atTime(23, 59, 59, 59)
+fun LocalDate.atEndOfDay(): LocalDateTime = this.atTime(23, 59, 59, 999_999_999)
+
+fun LocalDateTime.toServerZone(zoneId: ZoneId): LocalDateTime {
+    val serverTimezone = ZoneId.systemDefault()
+    return this
+        .atZone(zoneId)
+        .withZoneSameInstant(serverTimezone)
+        .toLocalDateTime()
+}
+
+fun LocalDateTime.toClientZone(zoneId: ZoneId): LocalDateTime {
+    val serverTimezone = ZoneId.systemDefault()
+    return this
+        .atZone(serverTimezone)
+        .withZoneSameInstant(zoneId)
+        .toLocalDateTime()
+}


### PR DESCRIPTION
## what is the PR Scope ?
- Improve timezone handling across all endpoints that deal with dates in wallet feature.

## why do we need that ?
- Statement endpoint was returning timestamps in server time not client time and first date endpoint were not returning it accounting for client timezone as well.

## end points with the request and response body:

### 1. Generate Statement Endpoint

#### Before
```bash
GET wallet/transactions/statement?type=DEPOSIT&from=2024-01-01T00:00:00&to=2024-01-31T23:59:59
```

#### After
```bash
GET wallet/transactions/statement?type=DEPOSIT&from=2024-01-01&to=2024-01-31
Accept-Timezone: Africa/Cairo
```

**Changes:**
- Added `Accept-Timezone` header (defaults to UTC)
- Changed from `LocalDateTime` to `LocalDate` (no time component needed)
- Parameters: `from` and `to` now use date format `YYYY-MM-DD` instead of `YYYY-MM-DDTHH:mm:ss`

---

### 2. Get First Transaction Date Endpoint

#### Before
```bash
GET wallet/transactions/first-date
```

#### After
```bash
GET wallet/transactions/first-date
Accept-Timezone: Asia/Baghdad
```

**Changes:**
- Added `Accept-Timezone` header (defaults to UTC)
- Response will now respect the client's timezone

---

### 3. Get Filtered Transactions Endpoint

#### Before
```bash
GET wallet/transactions?type=WITHDRAWAL&status=COMPLETED&from=2024-01-01T00:00:00&to=2024-01-31T23:59:59&page=0&size=20
```

#### After
```bash
GET wallet/transactions?type=WITHDRAWAL&status=COMPLETED&from=2024-01-01&to=2024-01-31&page=0&size=20
Accept-Timezone: Asia/Tokyo
```

**Changes:**
- Added `Accept-Timezone` header (defaults to UTC)
- Changed from `LocalDateTime` to `LocalDate` for `from` and `to` parameters
- Date parameters simplified to `YYYY-MM-DD` format
