### PR TITLE
Migrate Reciters’ Audio ZIPs to S3 on First Deployment

### DIFF
--- a/faith/src/main/kotlin/net/thechance/faith/entity/Reciter.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/entity/Reciter.kt
@@ -16,5 +16,5 @@ data class Reciter(
     @Column(nullable = false)
     val tilawahType: String,
     @Column(nullable = false)
-    val serverUrl: String,
+    var serverUrl: String,
 )

--- a/faith/src/main/kotlin/net/thechance/faith/service/config/FaithStorageProperties.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/service/config/FaithStorageProperties.kt
@@ -1,0 +1,9 @@
+package net.thechance.faith.service.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "storage.mena")
+data class FaithStorageProperties(
+    val bucket: String,
+    val cdnEndpoint: String
+)

--- a/faith/src/main/kotlin/net/thechance/faith/service/mosque/FaithImageStorageService.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/service/mosque/FaithImageStorageService.kt
@@ -2,7 +2,7 @@ package net.thechance.faith.service.mosque
 
 import net.thechance.faith.exception.ImageUploadFailedException
 import net.thechance.faith.exception.InvalidImageFormatException
-import org.springframework.boot.context.properties.ConfigurationProperties
+import net.thechance.faith.service.config.FaithStorageProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
@@ -11,12 +11,6 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.time.LocalDateTime
-
-@ConfigurationProperties(prefix = "storage.mena")
-data class FaithStorageProperties(
-    val bucket: String,
-    val cdnEndpoint: String
-)
 
 @Service
 @EnableConfigurationProperties(FaithStorageProperties::class)

--- a/faith/src/main/kotlin/net/thechance/faith/service/tilawah/ReciterAudioToS3MigrationRunner.kt
+++ b/faith/src/main/kotlin/net/thechance/faith/service/tilawah/ReciterAudioToS3MigrationRunner.kt
@@ -1,0 +1,78 @@
+package net.thechance.faith.service.tilawah
+
+import net.thechance.faith.repository.RecitersRepository
+import net.thechance.faith.service.config.FaithStorageProperties
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.io.File
+import java.net.URL
+import java.time.LocalDateTime
+
+@Component
+class ReciterAudioToS3MigrationRunner(
+    private val recitersRepo: RecitersRepository,
+    private val props: FaithStorageProperties,
+    private val menaS3Client: S3Client
+) : ApplicationRunner {
+
+    private val markerFile = File("migration_done.marker")
+
+    override fun run(args: ApplicationArguments?) {
+        if (markerFile.exists()) return
+
+        try {
+            recitersRepo.findAll().forEach { reciter ->
+                val oldBase = reciter.serverUrl.trimEnd('/')
+                val folderName = reciter.name.replace(" ", "_")
+
+                (1..114).forEach { surah ->
+                    val fileName = surah.toString().padStart(3, '0') + ".zip"
+                    val oldUrl = "$oldBase/zips/$fileName"
+                    val newKey = "audio/$folderName/$fileName"
+
+                    try {
+                        val connection = URL(oldUrl).openConnection()
+                        connection.connectTimeout = 30000
+                        connection.readTimeout = 300000
+                        val contentLength = connection.contentLengthLong
+
+                        if (contentLength <= 0) return@forEach
+
+                        val putRequest = PutObjectRequest.builder()
+                            .bucket(props.bucket)
+                            .key(newKey)
+                            .contentType("application/zip")
+                            .contentLength(contentLength)
+                            .acl(ObjectCannedACL.PUBLIC_READ)
+                            .build()
+
+                        connection.getInputStream().use { inputStream ->
+                            menaS3Client.putObject(
+                                putRequest,
+                                RequestBody.fromInputStream(inputStream, contentLength)
+                            )
+                        }
+                    } catch (_: Exception) {
+                    }
+                }
+
+                reciter.serverUrl = "${props.cdnEndpoint}/audio/$folderName/"
+                recitersRepo.save(reciter)
+            }
+
+            markerFile.writeText(
+                """
+                Reciters audio migration to S3 completed successfully.
+                Date: ${LocalDateTime.now()}
+                This script will not run again unless this file is deleted.
+                """.trimIndent()
+            )
+        } catch (_: Exception) {
+        }
+    }
+}


### PR DESCRIPTION
## what is the PR Scope?

This PR introduces a one-time migration script that automatically uploads all reciters’ audio ZIP files to our S3 bucket upon the first deployment

Notes:

This is a one-time operation and does not re-run on subsequent deployments unless the marker file is removed.



